### PR TITLE
pass LIBS to the linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ all: utox
 
 utox: $(OBJ) $(OS_OBJ) $(TRAY_OBJ)
 	@echo "  LD    $@"
-	@$(CC) $(CFLAGS) -o $(OUT_FILE) $(OBJ) $(OS_OBJ) $(TRAY_OBJ) $(LDFLAGS)
+	@$(CC) $(CFLAGS) -o $(OUT_FILE) $(OBJ) $(OS_OBJ) $(TRAY_OBJ) $(LDFLAGS) $(LIBS)
 
 install: utox
 	mkdir -p $(DESTDIR)$(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,22 @@ LDFLAGS += -pthread -lm
 # also link against these
 LIBS =
 
+ifeq ($(UNAME_S), Linux)
+	PKG_CONFIG = pkg-config
+else ifeq ($(UNAME_O), Cygwin)
+	PKG_CONFIG = x86_64-w64-mingw32-pkg-config
+else
+	PKG_CONFIG = false
+$(error unsupported platform)
+endif
+
 ifeq ($(FILTER_AUDIO), 1)
+ifeq ($(shell $(PKG_CONFIG) --exists filteraudio && echo yes), yes )
 	DEPS += filteraudio
+else
+$(warning pkg-config does not know about filteraudio, this might not work)
+$(error consider setting FILTER_AUDIO=0)
+endif
 	CFLAGS += -DAUDIO_FILTERING
 endif
 
@@ -45,8 +59,6 @@ ifeq ($(UNAME_S), Linux)
 		CFLAGS += -DNO_DBUS
 	endif
 
-	PKG_CONFIG = pkg-config
-
 	CFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 
 	LDFLAGS += -lresolv -ldl
@@ -67,7 +79,6 @@ else ifeq ($(UNAME_O), Cygwin)
 	CFLAGS  += -static
 	LDFLAGS += /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libwinpthread.a
 
-	PKG_CONFIG = x86_64-w64-mingw32-pkg-config
 	CFLAGS  += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 	LDFLAGS += $(shell $(PKG_CONFIG) --libs   $(DEPS))
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,11 @@ DEPS = libtoxav libtoxcore openal vpx libsodium
 UNAME_S := $(shell uname -s)
 UNAME_O := $(shell uname -o)
 
-# flags passed to the C compiler
 CFLAGS += -g -Wall -Wshadow -pthread -std=gnu99 -fno-strict-aliasing
-
-# linker flags
 LDFLAGS += -pthread -lm
 
-# link the executable against these
-LIBS +=
+# also link against these
+LIBS =
 
 ifeq ($(FILTER_AUDIO), 1)
 	DEPS += filteraudio
@@ -52,8 +49,8 @@ ifeq ($(UNAME_S), Linux)
 
 	CFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 
-	LIBS += -lresolv -ldl
-	LIBS += $(shell $(PKG_CONFIG) --libs $(DEPS))
+	LDFLAGS += -lresolv -ldl
+	LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
 
 	OS_SRC = $(wildcard src/xlib/*.c)
 	OS_OBJ = $(OS_SRC:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,14 @@ DEPS = libtoxav libtoxcore openal vpx libsodium
 UNAME_S := $(shell uname -s)
 UNAME_O := $(shell uname -o)
 
+# flags passed to the C compiler
 CFLAGS += -g -Wall -Wshadow -pthread -std=gnu99 -fno-strict-aliasing
+
+# linker flags
 LDFLAGS += -pthread -lm
+
+# link the executable against these
+LIBS +=
 
 ifeq ($(FILTER_AUDIO), 1)
 	DEPS += filteraudio
@@ -46,8 +52,8 @@ ifeq ($(UNAME_S), Linux)
 
 	CFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 
-	LDFLAGS += -lresolv -ldl
-	LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
+	LIBS += -lresolv -ldl
+	LIBS += $(shell $(PKG_CONFIG) --libs $(DEPS))
 
 	OS_SRC = $(wildcard src/xlib/*.c)
 	OS_OBJ = $(OS_SRC:.c=.o)


### PR DESCRIPTION
please allow to inject libs, in case pkg-config fails.

pkgconfig seems broken all the time here (don't ask me why). in this situation, this patch re-enables the build. `make CFLAGS=this LIBS=that`.

(this is related to https://github.com/qTox/qTox/issues/3374, other tox clients also use pkg-config)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grayhatter/utox/414)
<!-- Reviewable:end -->
