### PR TITLE
Add wait() to xlib to reap terminated child procs

### DIFF
--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -218,6 +218,8 @@ void openurl(char_t *str)
     if(!fork()) {
         execlp(cmd, cmd, str, (char *)0);
         exit(127);
+    } else {
+        waitpid(-1, NULL, WNOHANG);
     }
 }
 

--- a/src/xlib/main.h
+++ b/src/xlib/main.h
@@ -22,6 +22,9 @@
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 
+#include <sys/types.h>
+#include <sys/wait.h>
+
 #include <pthread.h>
 #include <unistd.h>
 #include <locale.h>


### PR DESCRIPTION
uTox with Xlib does not reap terminated child processes, such as the xdg-open command called by uTox's openurl(). The following is not a "real" fix: child pids aren't tracked, no messages print on child errors but it does:
1. free zombies without glib or global child pid tables, and
2. reduce outstanding zombies to one at any time,
3. without blocking and
4. without looping/polling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grayhatter/utox/415)
<!-- Reviewable:end -->
