### PR TITLE
Updated Windows section of BUILD.md

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -78,16 +78,16 @@ If you have mingw-w64 and a working cygwin enviroment, the build script provided
 tools/ should just work. You must tell it if you want 32 or 64 bit, then the enviroment
  you want to use.
 
-64bit should be `tools/cross-compile-windows.sh`
+64bit should be `tools/cygwin-compile.sh`
 
-32bit should be `tools/cross-compile-windows.sh -32`
+32bit should be `tools/cygwin-compile.sh -32`
 
 Make sure you grab a copy of toxcore, openal, and filter_audio from 
-https://jenkins.libtoxcore.so/ (Make sure you grab the right bit version.)
+https://build.tox.chat/ (Make sure you grab the right bit version.)
 
 You can also cross compile from unix if that's more your thing; again you'll need mingw-w64 and then just:
 
-`tools/cross-compile-windows.sh -unix`
+`tools/cygwin-compile.sh -unix`
 
 Don't forget to add -32 if you'd rather build the 32bit version.
 


### PR DESCRIPTION
cross-compile.sh has been renamed to cygwin-compile.sh and https://jenkins.libtoxcore.so/ 404s, so updated that to point to https://build.tox.chat/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/461)
<!-- Reviewable:end -->
