### PR TITLE
Avatar refactor

### DIFF
--- a/src/avatar.c
+++ b/src/avatar.c
@@ -124,17 +124,6 @@ void avatar_unset_self(void) {
     avatar_unset(self.avatar);
 }
 
-
-/** tries to load avatar from disk for given client id string and set avatar based on saved png data
- *  avatar is avatar to initialize. Will be unset if no file is found on disk or if file is corrupt or too large,
- *      otherwise will be set to avatar found on disk
- *  id is cid string of whose avatar to find(see also avatar_load in avatar.c)
- *  if png_data_out is not NULL, the png data loaded from disk will be copied to it.
- *      if it is not null, it should be at least UTOX_AVATAR_MAX_DATA_LENGTH bytes long
- *  if png_size_out is not null, the size of the png data will be stored in it
- *
- *  returns: true on successful loading, false on failure
- */
 bool avatar_init(char hexid[TOX_PUBLIC_KEY_SIZE * 2], AVATAR *avatar) {
     avatar_unset(avatar);
     return avatar_load(hexid, avatar, NULL);

--- a/src/avatar.c
+++ b/src/avatar.c
@@ -42,7 +42,7 @@ static uint8_t *load_img_data(char hexid[TOX_PUBLIC_KEY_SIZE * 2], size_t *out_s
     char name[sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png")] = { 0 };
 
 #ifdef __WIN32__
-    snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatar\\%.*s.png",
+    snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatars\\%.*s.png",
              TOX_PUBLIC_KEY_SIZE * 2, hexid);
 #else
     snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatars/%.*s.png",

--- a/src/avatar.c
+++ b/src/avatar.c
@@ -14,16 +14,11 @@ static void avatar_free_image(AVATAR *avatar) {
 }
 
 bool avatar_save(char hexid[TOX_PUBLIC_KEY_SIZE * 2], const uint8_t *data, size_t length) {
-    char name[sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png")];
+    char name[sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png")] = { 0 };
     FILE *fp;
 
-#ifdef __WIN32__
-    snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatars\\%.*s.png",
-             TOX_PUBLIC_KEY_SIZE * 2, hexid);
-#else
     snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatars/%.*s.png",
              TOX_PUBLIC_KEY_SIZE * 2, hexid);
-#endif
 
     fp = native_get_file(name, NULL, UTOX_FILE_OPTS_WRITE);
 
@@ -41,13 +36,8 @@ bool avatar_save(char hexid[TOX_PUBLIC_KEY_SIZE * 2], const uint8_t *data, size_
 static uint8_t *load_img_data(char hexid[TOX_PUBLIC_KEY_SIZE * 2], size_t *out_size) {
     char name[sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png")] = { 0 };
 
-#ifdef __WIN32__
-    snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatars\\%.*s.png",
-             TOX_PUBLIC_KEY_SIZE * 2, hexid);
-#else
     snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatars/%.*s.png",
              TOX_PUBLIC_KEY_SIZE * 2, hexid);
-#endif
 
     size_t size = 0;
 
@@ -79,20 +69,15 @@ static uint8_t *load_img_data(char hexid[TOX_PUBLIC_KEY_SIZE * 2], size_t *out_s
 }
 
 bool avatar_delete(char hexid[TOX_PUBLIC_KEY_SIZE * 2]) {
-    char name[sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png")];
+    char name[sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png")] = { 0 };
 
-#ifdef __WIN32__
     int name_len = snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"),
-                            "avatars/%.*s.png", TOX_PUBLIC_KEY_SIZE * 2, (char *)hexid);
-#else
-    int name_len = snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"),
-                            "avatars\\%.*s.png", TOX_PUBLIC_KEY_SIZE * 2, (char *)hexid);
-#endif
+                            "avatars/%.*s.png", TOX_PUBLIC_KEY_SIZE * 2, hexid);
 
     return native_remove_file(name, name_len);
 }
 
-static bool load_avatar(char hexid[TOX_PUBLIC_KEY_SIZE * 2], AVATAR *avatar, size_t *size_out) {
+static bool avatar_load(char hexid[TOX_PUBLIC_KEY_SIZE * 2], AVATAR *avatar, size_t *size_out) {
     size_t size = 0;
 
     uint8_t *img = load_img_data(hexid, &size);
@@ -169,7 +154,7 @@ void avatar_unset_self(void) {
 /** tries to load avatar from disk for given client id string and set avatar based on saved png data
  *  avatar is avatar to initialize. Will be unset if no file is found on disk or if file is corrupt or too large,
  *      otherwise will be set to avatar found on disk
- *  id is cid string of whose avatar to find(see also load_avatar in avatar.h)
+ *  id is cid string of whose avatar to find(see also avatar_load in avatar.c)
  *  if png_data_out is not NULL, the png data loaded from disk will be copied to it.
  *      if it is not null, it should be at least UTOX_AVATAR_MAX_DATA_LENGTH bytes long
  *  if png_size_out is not null, the size of the png data will be stored in it
@@ -178,7 +163,7 @@ void avatar_unset_self(void) {
  */
 bool avatar_init(char hexid[TOX_PUBLIC_KEY_SIZE * 2], AVATAR *avatar) {
     avatar_unset(avatar);
-    return load_avatar(hexid, avatar, NULL);
+    return avatar_load(hexid, avatar, NULL);
 }
 
 bool avatar_init_self(void) {
@@ -187,7 +172,7 @@ bool avatar_init_self(void) {
         return false;
     }
 
-    return load_avatar(self.id_str, self.avatar, NULL);
+    return avatar_load(self.id_str, self.avatar, NULL);
 }
 
 bool self_set_and_save_avatar(const uint8_t *data, uint32_t size) {

--- a/src/avatar.c
+++ b/src/avatar.c
@@ -39,33 +39,7 @@ static uint8_t *load_img_data(char hexid[TOX_PUBLIC_KEY_SIZE * 2], size_t *out_s
     snprintf(name, sizeof("avatars/") + TOX_PUBLIC_KEY_SIZE * 2 + sizeof(".png"), "avatars/%.*s.png",
              TOX_PUBLIC_KEY_SIZE * 2, hexid);
 
-    size_t size = 0;
-
-    FILE *fp = native_get_file(name, &size, UTOX_FILE_OPTS_READ);
-    if (fp == NULL) {
-        debug("Avatars:\tCould not open avatar for friend : %.*s\n", (int)sizeof(*hexid), hexid);
-        return NULL;
-    }
-
-    uint8_t *data = calloc(size, 1);
-    if (data == NULL) {
-        debug("Avatars:\tCould not allocate memory for avatar of size %lu.\n", size);
-        fclose(fp);
-        return NULL;
-    }
-
-    if (fread(data, 1, size, fp) != size) {
-        debug("Avatars:\tCould not read: avatar for friend : %.*s\n", (int)sizeof(*hexid), hexid);
-        fclose(fp);
-        free(data);
-        return NULL;
-    }
-
-    fclose(fp);
-    if (out_size) {
-        *out_size = size;
-    }
-    return data;
+    return load_data(name, out_size);
 }
 
 bool avatar_delete(char hexid[TOX_PUBLIC_KEY_SIZE * 2]) {

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -9,9 +9,9 @@
 #define UTOX_AVATAR_FORMAT_NONE 0
 #define UTOX_AVATAR_FORMAT_PNG 1
 
-/* data needed for each avatar in memory */
+/* Data needed for each avatar in memory. */
 typedef struct avatar {
-    NATIVE_IMAGE *img; /* converted avatar image to draw */
+    NATIVE_IMAGE *img; /* Converted avatar image to draw. */
 
     size_t   size;
     uint16_t width, height;         /* width and height of image (in pixels) */
@@ -19,53 +19,62 @@ typedef struct avatar {
     uint8_t  hash[TOX_HASH_LENGTH]; /* tox_hash for the png data of this avatar */
 } AVATAR;
 
-/* whether user's avatar is set */
+/* Whether user's avatar is set. */
 #define self_has_avatar() (self.avatar && self.avatar->format != UTOX_AVATAR_FORMAT_NONE)
-/* whether friend f's avatar is set, where f is a pointer to a friend struct */
+/* Whether friend f's avatar is set, where f is a pointer to a friend struct */
 #define friend_has_avatar(f) (f) && (f->avatar.format != UTOX_AVATAR_FORMAT_NONE)
 
+/** tries to load avatar from disk for given client id string and set avatar based on saved png data
+ * avatar is avatar to initialize. Will be unset if no file is found on disk or if file is corrupt or too large,
+ *     otherwise will be set to avatar found on disk
+ * id is cid string of whose avatar to find(see also avatar_load in avatar.c)
+ * if png_data_out is not NULL, the png data loaded from disk will be copied to it.
+ *     if it is not null, it should be at least UTOX_AVATAR_MAX_DATA_LENGTH bytes long
+ * if png_size_out is not null, the size of the png data will be stored in it
+ *
+ * returns: true on successful loading, false on failure
+ */
 bool avatar_init(char hexid[TOX_PUBLIC_KEY_SIZE * 2], AVATAR *avatar);
 
-/* converts png data given by data to a NATIVE_IMAGE and uses that to populate the avatar struct
- *  avatar is pointer to an avatar struct to store result in. Remains unchanged if function fails.
- *  data is pointer to png data to convert
- *  size is size of data
+/** Converts png data given by data to a NATIVE_IMAGE and uses that to populate the avatar struct
+ * avatar is pointer to an avatar struct to store result in. Remains unchanged if function fails.
+ * data is pointer to png data to convert
+ * size is size of data
  *
- *  on success: returns true
- *  on failure: returns false
+ * on success: returns true
+ * on failure: returns false
  *
- *  notes: fails if given size is larger than UTOX_AVATAR_MAX_DATA_LENGTH or data is not valid PNG data
+ * notes: fails if given size is larger than UTOX_AVATAR_MAX_DATA_LENGTH or data is not valid PNG data
  */
 bool avatar_set(AVATAR *avatar, const uint8_t *data, size_t size);
 
-/** Helper function for the users avatar */
+/* Helper function to set the user's avatar. */
 bool avatar_set_self(const uint8_t *data, size_t size);
 
-/* unsets an avatar by setting its format to UTOX_AVATAR_FORMAT_NONE and
- * freeing its image */
-void avatar_unset(AVATAR *avatar);
-
-/* Helper function to unset the user's avatar */
+/* Helper function to unset the user's avatar. */
 void avatar_unset_self(void);
 
-/* sets own avatar based on given png data and saves it to disk if successful
- *  data is png data to set avatar to
- *  size is size of data
+/* Unsets an avatar by setting its format to UTOX_AVATAR_FORMAT_NONE and freeing its image. */
+void avatar_unset(AVATAR *avatar);
+
+/** Sets own avatar based on given png data and saves it to disk if successful.
+ * data is png data to set avatar to.
+ * size is size of data.
  *
- *  on success: returns 1
- *  on failure: returns 0
+ * on success: returns true
+ * on failure: returns false
  *
- *  notes: fails if size is too large or data is not a valid png file
+ * Notes: Fails if size is too large or data is not a valid png file.
  */
 bool self_set_and_save_avatar(const uint8_t *data, uint32_t size);
 
-/* unsets own avatar and removes it from disk */
+/* Unsets own avatar and removes it from disk */
 bool avatar_remove_self(void);
 
-/* Call this every time friend_number goes online from the tox_do thread.
+/** Call this every time friend_number goes online from the tox_do thread.
  *
- * return 1 on success.
- * return 0 on failure.
+ *  on success: returns true
+ *  on failure: returns false
  */
 bool avatar_on_friend_online(Tox *tox, uint32_t friend_number);
 

--- a/src/util.c
+++ b/src/util.c
@@ -605,6 +605,37 @@ void scale_rgbx_image(uint8_t *old_rgbx, uint16_t old_width, uint16_t old_height
     }
 }
 
+uint8_t *load_data(uint8_t *filepath, size_t *out_size) {
+    size_t size = 0;
+
+    FILE *fp = native_get_file(filepath, &size, UTOX_FILE_OPTS_READ);
+    if (fp == NULL) {
+        debug("Util:\tCould not open file for reading: %s\n", filepath);
+        return NULL;
+    }
+
+    uint8_t *data = calloc(size, 1);
+    if (data == NULL) {
+        debug("Util:\tCould not allocate memory for file of size %zu.\n", size);
+        fclose(fp);
+        return NULL;
+    }
+
+    if (fread(data, 1, size, fp) != size) {
+        debug("Util:\tCould not read file: %s\n", filepath);
+        fclose(fp);
+        free(data);
+        return NULL;
+    }
+
+    fclose(fp);
+    if (out_size) {
+        *out_size = size;
+    }
+
+    return data;
+}
+
 UTOX_SAVE *config_load(void) {
     UTOX_SAVE *save;
     save = utox_data_load_utox();

--- a/src/util.h
+++ b/src/util.h
@@ -99,6 +99,14 @@ void bgrxtoyuv420(uint8_t *plane_y, uint8_t *plane_u, uint8_t *plane_v, uint8_t 
 void scale_rgbx_image(uint8_t *old_rgbx, uint16_t old_width, uint16_t old_height, uint8_t *new_rgbx, uint16_t new_width,
                       uint16_t new_height);
 
+
+/** Loads data from file at filepath. 
+ *  Size of data loaded is written to out_size.
+ *  Returns data loaded.
+ *  Notes: It is the caller's responsibility to free the data when it is no longer needed.
+ */
+uint8_t *load_data(uint8_t *filepath, size_t *out_size);
+
 /*
  */
 UTOX_SAVE *config_load(void);


### PR DESCRIPTION
Fixes among other things, avatar paths being broken on Windows. 

Must be merged after #511 as this changes avatars to only use Linux-style paths and #511 makes Windows handle those correctly.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/510)
<!-- Reviewable:end -->
