### PR TITLE
Fix utox target installation rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,9 +144,6 @@ elseif(UNIX) # xlib by default
     target_link_libraries(utoxNATIVE icon v4lconvert X11 Xext Xrender fontconfig freetype resolv dl )
 
 	install(FILES
-	  utox
-	  DESTINATION "bin")
-	install(FILES
 	  src/utox.desktop
 	  DESTINATION "share/applications")
 	install(FILES
@@ -270,3 +267,6 @@ target_link_libraries(utox
                       sodium        pthread     m   vpx )
 
 set_property(TARGET utox PROPERTY C_STANDARD 99)
+if(UNIX)
+	install(TARGETS utox RUNTIME DESTINATION "bin")
+endif()


### PR DESCRIPTION
CMake install rules for files generated by the build process must specify
they reference a target to be correctly looked up in the build directory,
instead of the source directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/515)
<!-- Reviewable:end -->
