### PR TITLE
Fix segv in ft_find_resumeable in file_transfer.c on Windows

### DIFF
--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -189,11 +189,11 @@ static bool ft_find_resumeable(FILE_TRANSFER *ft) {
     FILE_TRANSFER resume_data;
     fread(&resume_data, 1, size, resume_file);
 
-    if (!resume_data.in_use
+    if (!resume_data.resumeable
+        || !resume_data.in_use
         || resume_data.in_memory
         || resume_data.avatar
-        || resume_data.inline_img
-        || !resume_data.resumeable ) {
+        || resume_data.inline_img) {
         return false;
     }
 

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -182,17 +182,19 @@ static bool ft_find_resumeable(FILE_TRANSFER *ft) {
         return false;
     }
 
-    FILE_TRANSFER resume_data;
-    if (size == sizeof(FILE_TRANSFER)) {
-        fread(&resume_data, 1, size, resume_file);
+    if (size != sizeof(FILE_TRANSFER)) {
+        return false;
+    }
 
-        if (!resume_data.in_use
-            || resume_data.in_memory
-            || resume_data.avatar
-            || resume_data.inline_img
-            || !resume_data.resumeable ) {
-            return false;
-        }
+    FILE_TRANSFER resume_data;
+    fread(&resume_data, 1, size, resume_file);
+
+    if (!resume_data.in_use
+        || resume_data.in_memory
+        || resume_data.avatar
+        || resume_data.inline_img
+        || !resume_data.resumeable ) {
+        return false;
     }
 
     memcpy(ft, &resume_data, sizeof(FILE_TRANSFER));

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -199,7 +199,7 @@ static bool ft_find_resumeable(FILE_TRANSFER *ft) {
 
     ft->name_length = 0;
     uint8_t *p = ft->path + strlen((char *)ft->path);
-    while (*--p != '/') {
+    while (*--p != '/' || *p == '\\') {
         ++ft->name_length;
     }
     ++p;

--- a/src/windows/filesys.c
+++ b/src/windows/filesys.c
@@ -92,7 +92,7 @@ FILE *native_get_file(const uint8_t *name, size_t *size, UTOX_FILE_OPTS opts) {
 
     if (fp == NULL) {
         if (opts > UTOX_FILE_OPTS_READ) {
-            debug_error("Windows:\tCould not open %s\n", path);
+            debug_notice("Windows:\tCould not open %s\n", path);
         }
         return NULL;
     }

--- a/src/windows/filesys.c
+++ b/src/windows/filesys.c
@@ -6,7 +6,7 @@ static FILE* get_file(wchar_t path[UTOX_FILE_NAME_LENGTH], UTOX_FILE_OPTS opts) 
     // assert(UTOX_FILE_NAME_LENGTH <= (32,767 wide characters) );
     DWORD rw  = 0;
     char mode[4] = { 0 };
-    DWORD create = OPEN_ALWAYS;
+    DWORD create = OPEN_EXISTING;
 
     if (opts & UTOX_FILE_OPTS_READ) {
         rw |= GENERIC_READ;
@@ -16,6 +16,7 @@ static FILE* get_file(wchar_t path[UTOX_FILE_NAME_LENGTH], UTOX_FILE_OPTS opts) 
     if (opts & UTOX_FILE_OPTS_APPEND) {
         rw |= GENERIC_WRITE;
         mode[0] = 'a';
+        create = OPEN_ALWAYS;
     } else if (opts & UTOX_FILE_OPTS_WRITE) {
         rw |= GENERIC_WRITE;
         mode[0] = 'w';
@@ -90,7 +91,9 @@ FILE *native_get_file(const uint8_t *name, size_t *size, UTOX_FILE_OPTS opts) {
     FILE *fp = get_file(wide, opts);
 
     if (fp == NULL) {
-        debug_error("Windows:\tCould not open %s\n", path);
+        if (opts > UTOX_FILE_OPTS_READ) {
+            debug_error("Windows:\tCould not open %s\n", path);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
Also stop Windows `native_get_file `from creating files when passing READ to it.
Also silences warnings RE: not creating files when passing READ to `native_get_file`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/546)
<!-- Reviewable:end -->
