### PR TITLE
Write '\0' instead of 0 in ft_decon_resumeable

### DIFF
--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -154,7 +154,7 @@ static void ft_decon_resumable(FILE_TRANSFER *ft) {
     }
 
     // Write \0 and flush before delete
-    fwrite(0, 1, size, file);
+    fwrite('\0', 1, size, file);
     fflush(file);
     fclose(file);
     file = native_get_file(name, &size, UTOX_FILE_OPTS_DELETE);


### PR DESCRIPTION
Fixes #556

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/559)
<!-- Reviewable:end -->
