### PR TITLE
Hotfix: drop a bad attempt at secure erase

### DIFF
--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -153,9 +153,6 @@ static void ft_decon_resumable(FILE_TRANSFER *ft) {
         return;
     }
 
-    // Write \0 and flush before delete
-    fwrite('\0', 1, size, file);
-    fflush(file);
     fclose(file);
     file = native_get_file(name, &size, UTOX_FILE_OPTS_DELETE);
 }


### PR DESCRIPTION
We can't actually do any attempt at secure erase from within uTox.
False security is worse than no security, so in this case we just
blindly hope the user is using full disk encryption.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/561)
<!-- Reviewable:end -->
