### PR TITLE
Fixed Hanging GUI when changing network settings

### DIFF
--- a/langs/de.h
+++ b/langs/de.h
@@ -289,7 +289,7 @@ msgstr("Kompakte Kontaktliste verwenden")
 msgid(NOT_CONNECTED)
 msgstr("Nicht verbunden")
 
-msgid(NOT_CONNECTED_ERROR)
+msgid(NOT_CONNECTED_SETTINGS)
 msgstr("Netzwerk Einstellungen anpassen")
 
 msgid(OTHERSETTINGS)

--- a/langs/de.h
+++ b/langs/de.h
@@ -289,6 +289,9 @@ msgstr("Kompakte Kontaktliste verwenden")
 msgid(NOT_CONNECTED)
 msgstr("Nicht verbunden")
 
+msgid(NOT_CONNECTED_ERROR)
+msgstr("Netzwerk Einstellungen anpassen")
+
 msgid(OTHERSETTINGS)
 msgstr("Andere Einstellungen")
 

--- a/langs/en.h
+++ b/langs/en.h
@@ -376,7 +376,7 @@ msgstr("Use mini contact list")
 msgid(NOT_CONNECTED)
 msgstr("Not Connected")
 
-msgid(NOT_CONNECTED_ERROR)
+msgid(NOT_CONNECTED_SETTINGS)
 msgstr("Adjust network settings")
 
 msgid(OTHERSETTINGS)

--- a/langs/en.h
+++ b/langs/en.h
@@ -376,6 +376,9 @@ msgstr("Use mini contact list")
 msgid(NOT_CONNECTED)
 msgstr("Not Connected")
 
+msgid(NOT_CONNECTED_ERROR)
+msgstr("Adjust network settings")
+
 msgid(OTHERSETTINGS)
 msgstr("Other Settings")
 

--- a/langs/i18n_decls.h
+++ b/langs/i18n_decls.h
@@ -160,6 +160,7 @@ typedef enum {
 
     // Status strings
     STR_NOT_CONNECTED,
+    STR_NOT_CONNECTED_ERROR,
 
     // Setting strings
     STR_OTHERSETTINGS,

--- a/langs/i18n_decls.h
+++ b/langs/i18n_decls.h
@@ -160,7 +160,7 @@ typedef enum {
 
     // Status strings
     STR_NOT_CONNECTED,
-    STR_NOT_CONNECTED_ERROR,
+    STR_NOT_CONNECTED_SETTINGS,
 
     // Setting strings
     STR_OTHERSETTINGS,

--- a/src/android/main.c
+++ b/src/android/main.c
@@ -720,6 +720,7 @@ static void android_main(struct android_app *state) {
     dropdown_dpi.selected = dropdown_dpi.over = 15;
     ui_set_scale(21);
 
+    /* wait for tox thread to start */
     while (!tox_thread_init) {
         yieldcpu(1);
     }

--- a/src/commands.c
+++ b/src/commands.c
@@ -134,7 +134,7 @@ void do_tox_url(uint8_t *url_string, int len) {
         a++;
     }
 
-    if (!tox_thread_init || tox_thread_error) {
+    if (tox_thread_init != UTOX_TOX_THREAD_INIT_SUCCESS) {
         // if we receive a URL event before the profile is loaded, save it for later.
         // this usually happens when we are launched as the result of a URL click.
         g_select_add_friend_later = 1;

--- a/src/commands.c
+++ b/src/commands.c
@@ -134,7 +134,7 @@ void do_tox_url(uint8_t *url_string, int len) {
         a++;
     }
 
-    if (!tox_thread_init) {
+    if (!tox_thread_init || tox_thread_error) {
         // if we receive a URL event before the profile is loaded, save it for later.
         // this usually happens when we are launched as the result of a URL click.
         g_select_add_friend_later = 1;

--- a/src/main.h
+++ b/src/main.h
@@ -170,7 +170,18 @@ volatile uint16_t loaded_audio_in_device, loaded_audio_out_device;
 bool tox_connected;
 
 /* Super global vars */
-volatile bool tox_thread_init, tox_thread_error, utox_av_ctrl_init, utox_audio_thread_init, utox_video_thread_init;
+volatile bool utox_av_ctrl_init, utox_audio_thread_init, utox_video_thread_init;
+volatile enum {
+    // tox_thread is not initialized yet
+    UTOX_TOX_THREAD_INIT_NONE = 0,
+    // tox_thread is initialized successfully
+    // this means a tox instance has been created
+    UTOX_TOX_THREAD_INIT_SUCCESS = 1,
+    // tox_thread is initialized but not successfully
+    // this means a tox instance may have not been created
+    UTOX_TOX_THREAD_INIT_ERROR = 2,
+} tox_thread_init;
+
 
 double ui_scale;
 

--- a/src/main.h
+++ b/src/main.h
@@ -171,7 +171,7 @@ bool tox_connected;
 
 /* Super global vars */
 volatile bool utox_av_ctrl_init, utox_audio_thread_init, utox_video_thread_init;
-volatile enum {
+typedef enum {
     // tox_thread is not initialized yet
     UTOX_TOX_THREAD_INIT_NONE = 0,
     // tox_thread is initialized successfully
@@ -180,7 +180,9 @@ volatile enum {
     // tox_thread is initialized but not successfully
     // this means a tox instance may have not been created
     UTOX_TOX_THREAD_INIT_ERROR = 2,
-} tox_thread_init;
+} UTOX_TOX_THREAD_INIT;
+
+UTOX_TOX_THREAD_INIT tox_thread_init;
 
 
 double ui_scale;

--- a/src/main.h
+++ b/src/main.h
@@ -170,7 +170,7 @@ volatile uint16_t loaded_audio_in_device, loaded_audio_out_device;
 bool tox_connected;
 
 /* Super global vars */
-volatile bool tox_thread_init, utox_av_ctrl_init, utox_audio_thread_init, utox_video_thread_init;
+volatile bool tox_thread_init, tox_thread_error, utox_av_ctrl_init, utox_audio_thread_init, utox_video_thread_init;
 
 double ui_scale;
 

--- a/src/tox.c
+++ b/src/tox.c
@@ -349,7 +349,7 @@ static int init_toxcore(Tox **tox) {
     }
 
     // Create main connection
-    debug("CORE:\tCreating New Toxcore instance.\n"
+    debug_notice("CORE:\tCreating New Toxcore instance.\n"
           "\t\tIPv6 : %u\n"
           "\t\tUDP  : %u\n"
           "\t\tProxy: %u %s %u\n",
@@ -362,10 +362,10 @@ static int init_toxcore(Tox **tox) {
 
     if (*tox == NULL) {
         if (settings.force_proxy) {
-            debug("\t\tError #%u, Not going to try without proxy because of user settings.\n", tox_new_err);
+            debug_error("\t\tError #%u, Not going to try without proxy because of user settings.\n", tox_new_err);
             return -2;
         }
-        debug("\t\tError #%u, Going to try without proxy.\n", tox_new_err);
+        debug_error("\t\tError #%u, Going to try without proxy.\n", tox_new_err);
 
         // reset proxy options as well as GUI and settings
         topt.proxy_type = TOX_PROXY_TYPE_NONE;
@@ -375,7 +375,7 @@ static int init_toxcore(Tox **tox) {
         *tox = tox_new(&topt, &tox_new_err);
 
         if (*tox == NULL) {
-            debug("\t\tError #%u, Going to try without IPv6.\n", tox_new_err);
+            debug_error("\t\tError #%u, Going to try without IPv6.\n", tox_new_err);
 
             // reset IPv6 options as well as GUI and settings
             topt.ipv6_enabled = 0;
@@ -384,7 +384,7 @@ static int init_toxcore(Tox **tox) {
             *tox = tox_new(&topt, &tox_new_err);
 
             if (*tox == NULL) {
-                debug("\t\tFatal Error creating a Tox instance... Error #%u\n", tox_new_err);
+                debug_error("\t\tFatal Error creating a Tox instance... Error #%u\n", tox_new_err);
                 return -2;
             }
         }

--- a/src/ui/buttons.c
+++ b/src/ui/buttons.c
@@ -58,7 +58,7 @@ static void button_avatar_on_mup(void) {
 
 static void button_name_on_mup(void) {
     flist_selectsettings();
-    if (tox_thread_error) {
+    if (tox_thread_init != UTOX_TOX_THREAD_INIT_SUCCESS) {
         // jump to the network settings when unable to create tox instance
         panel_settings_profile.disabled = true;
         panel_settings_devices.disabled = true;
@@ -77,7 +77,7 @@ static void button_name_on_mup(void) {
 
 static void button_statusmsg_on_mup(void) {
     flist_selectsettings();
-    if (tox_thread_error) {
+    if (tox_thread_init != UTOX_TOX_THREAD_INIT_SUCCESS) {
         // jump to the network settings when unable to create tox instance
         panel_settings_profile.disabled = true;
         panel_settings_devices.disabled = true;
@@ -597,7 +597,7 @@ BUTTON button_export_chatlog = {
 extern SCROLLABLE scrollbar_settings;
 
 static void button_settings_on_mup(void) {
-    if (tox_thread_init) {
+    if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
         flist_selectsettings();
     }
 }

--- a/src/ui/buttons.c
+++ b/src/ui/buttons.c
@@ -51,7 +51,7 @@ void button_setcolors_disabled(BUTTON *b) {
 
 /* On-press functions followed by the update functions when needed... */
 static void button_avatar_on_mup(void) {
-    if (tox_thread_init) {
+    if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
         openfileavatar();
     }
 }
@@ -123,7 +123,7 @@ static void button_menu_update(BUTTON *b) {
 }
 
 static void button_add_new_contact_on_mup(void) {
-    if (tox_thread_init) {
+    if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
         /* Only change if we're logged in! */
         edit_setstr(&edit_add_id, (char *)edit_search.data, edit_search.length);
         edit_setstr(&edit_search, (char *)"", 0);

--- a/src/ui/buttons.c
+++ b/src/ui/buttons.c
@@ -58,22 +58,40 @@ static void button_avatar_on_mup(void) {
 
 static void button_name_on_mup(void) {
     flist_selectsettings();
-    panel_settings_profile.disabled = false;
-    panel_settings_devices.disabled = true;
-    panel_settings_net.disabled     = true;
-    panel_settings_ui.disabled      = true;
-    panel_settings_av.disabled      = true;
-    edit_setfocus(&edit_name);
+    if (tox_thread_error) {
+        // jump to the network settings when unable to create tox instance
+        panel_settings_profile.disabled = true;
+        panel_settings_devices.disabled = true;
+        panel_settings_net.disabled = false;
+        panel_settings_ui.disabled = true;
+        panel_settings_av.disabled = true;
+    } else {
+        panel_settings_profile.disabled = false;
+        panel_settings_devices.disabled = true;
+        panel_settings_net.disabled = true;
+        panel_settings_ui.disabled = true;
+        panel_settings_av.disabled = true;
+        edit_setfocus(&edit_name);
+    }
 }
 
 static void button_statusmsg_on_mup(void) {
     flist_selectsettings();
-    panel_settings_profile.disabled = false;
-    panel_settings_devices.disabled = true;
-    panel_settings_net.disabled     = true;
-    panel_settings_ui.disabled      = true;
-    panel_settings_av.disabled      = true;
-    edit_setfocus(&edit_status);
+    if (tox_thread_error) {
+        // jump to the network settings when unable to create tox instance
+        panel_settings_profile.disabled = true;
+        panel_settings_devices.disabled = true;
+        panel_settings_net.disabled = false;
+        panel_settings_ui.disabled = true;
+        panel_settings_av.disabled = true;
+    } else {
+        panel_settings_profile.disabled = false;
+        panel_settings_devices.disabled = true;
+        panel_settings_net.disabled = true;
+        panel_settings_ui.disabled = true;
+        panel_settings_av.disabled = true;
+        edit_setfocus(&edit_status);
+    }
 }
 
 static void button_status_on_mup(void) {

--- a/src/ui/draw_helpers.c
+++ b/src/ui/draw_helpers.c
@@ -31,7 +31,7 @@ void draw_avatar_image(NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32
 
 /* Top left self interface Avatar, name, statusmsg, status icon */
 void draw_user_badge(int UNUSED(x), int UNUSED(y), int UNUSED(width), int UNUSED(height)) {
-    if (tox_thread_init) {
+    if (tox_thread_init && !tox_thread_error) {
         /* Only draw the user badge if toxcore is running */
         /*draw avatar or default image */
         if (self_has_avatar()) {
@@ -73,7 +73,12 @@ void draw_user_badge(int UNUSED(x), int UNUSED(y), int UNUSED(width), int UNUSED
 
         setcolor(!button_name.mouseover ? COLOR_MENU_TEXT : COLOR_MENU_TEXT_SUBTEXT);
         setfont(FONT_SELF_NAME);
-        drawtextrange(SIDEBAR_NAME_LEFT, SIDEBAR_NAME_WIDTH, SIDEBAR_NAME_TOP, S(NOT_CONNECTED), SLEN(NOT_CONNECTED));
+        drawtextrange(SIDEBAR_NAME_LEFT, SIDEBAR_WIDTH - SIDEBAR_AVATAR_LEFT, SIDEBAR_NAME_TOP, S(NOT_CONNECTED), SLEN(NOT_CONNECTED));
+
+        setcolor(!button_status_msg.mouseover ? COLOR_MENU_TEXT_SUBTEXT : COLOR_MAIN_TEXT_HINT);
+        setfont(FONT_STATUS);
+        drawtextrange(SIDEBAR_STATUSMSG_LEFT, SIDEBAR_WIDTH, SIDEBAR_STATUSMSG_TOP, S(NOT_CONNECTED_ERROR), SLEN(NOT_CONNECTED_ERROR));
+
     }
 }
 

--- a/src/ui/draw_helpers.c
+++ b/src/ui/draw_helpers.c
@@ -31,7 +31,7 @@ void draw_avatar_image(NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32
 
 /* Top left self interface Avatar, name, statusmsg, status icon */
 void draw_user_badge(int UNUSED(x), int UNUSED(y), int UNUSED(width), int UNUSED(height)) {
-    if (tox_thread_init && !tox_thread_error) {
+    if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
         /* Only draw the user badge if toxcore is running */
         /*draw avatar or default image */
         if (self_has_avatar()) {
@@ -75,10 +75,10 @@ void draw_user_badge(int UNUSED(x), int UNUSED(y), int UNUSED(width), int UNUSED
         setfont(FONT_SELF_NAME);
         drawtextrange(SIDEBAR_NAME_LEFT, SIDEBAR_WIDTH - SIDEBAR_AVATAR_LEFT, SIDEBAR_NAME_TOP, S(NOT_CONNECTED), SLEN(NOT_CONNECTED));
 
-        if (tox_thread_error) {
+        if (tox_thread_init == UTOX_TOX_THREAD_INIT_ERROR) {
             setcolor(!button_status_msg.mouseover ? COLOR_MENU_TEXT_SUBTEXT : COLOR_MAIN_TEXT_HINT);
             setfont(FONT_STATUS);
-            drawtextrange(SIDEBAR_STATUSMSG_LEFT, SIDEBAR_WIDTH, SIDEBAR_STATUSMSG_TOP, S(NOT_CONNECTED_ERROR), SLEN(NOT_CONNECTED_ERROR));
+            drawtextrange(SIDEBAR_STATUSMSG_LEFT, SIDEBAR_WIDTH, SIDEBAR_STATUSMSG_TOP, S(NOT_CONNECTED_SETTINGS), SLEN(NOT_CONNECTED_SETTINGS));
         }
     }
 }

--- a/src/ui/draw_helpers.c
+++ b/src/ui/draw_helpers.c
@@ -75,10 +75,11 @@ void draw_user_badge(int UNUSED(x), int UNUSED(y), int UNUSED(width), int UNUSED
         setfont(FONT_SELF_NAME);
         drawtextrange(SIDEBAR_NAME_LEFT, SIDEBAR_WIDTH - SIDEBAR_AVATAR_LEFT, SIDEBAR_NAME_TOP, S(NOT_CONNECTED), SLEN(NOT_CONNECTED));
 
-        setcolor(!button_status_msg.mouseover ? COLOR_MENU_TEXT_SUBTEXT : COLOR_MAIN_TEXT_HINT);
-        setfont(FONT_STATUS);
-        drawtextrange(SIDEBAR_STATUSMSG_LEFT, SIDEBAR_WIDTH, SIDEBAR_STATUSMSG_TOP, S(NOT_CONNECTED_ERROR), SLEN(NOT_CONNECTED_ERROR));
-
+        if (tox_thread_error) {
+            setcolor(!button_status_msg.mouseover ? COLOR_MENU_TEXT_SUBTEXT : COLOR_MAIN_TEXT_HINT);
+            setfont(FONT_STATUS);
+            drawtextrange(SIDEBAR_STATUSMSG_LEFT, SIDEBAR_WIDTH, SIDEBAR_STATUSMSG_TOP, S(NOT_CONNECTED_ERROR), SLEN(NOT_CONNECTED_ERROR));
+        }
     }
 }
 

--- a/src/ui/dropdowns.c
+++ b/src/ui/dropdowns.c
@@ -1,5 +1,6 @@
-// dropdows.h
 #include "dropdowns.h"
+
+#include "switches.h"
 
 #include "../av/utox_av.h"
 #include "../flist.h"
@@ -7,7 +8,6 @@
 #include "../groups.h"
 #include "../theme.h"
 #include "../util.h"
-#include "switches.h"
 
 
 static void dropdown_audio_in_onselect(uint16_t i, const DROPDOWN *dm) {

--- a/src/ui/dropdowns.c
+++ b/src/ui/dropdowns.c
@@ -7,6 +7,7 @@
 #include "../groups.h"
 #include "../theme.h"
 #include "../util.h"
+#include "switches.h"
 
 
 static void dropdown_audio_in_onselect(uint16_t i, const DROPDOWN *dm) {
@@ -48,19 +49,26 @@ static void dropdown_proxy_onselect(uint16_t i, const DROPDOWN *UNUSED(dm)) {
         case 0: {
             settings.use_proxy   = 0;
             settings.force_proxy = 0;
+            switch_udp.disabled = 0;
             break;
         }
 
         case 1: {
             settings.use_proxy   = 1;
             settings.force_proxy = 0;
+            switch_udp.disabled = 0;
             break;
         }
 
         case 2: {
             settings.use_proxy   = 1;
             settings.force_proxy = 1;
-            settings.enable_udp  = 0;
+            // disable UDP in this case, proxy only allows TCP
+            if (settings.enable_udp) {
+                settings.enable_udp = 0;
+                switch_udp.switch_on = 0;
+            }
+            switch_udp.disabled = 1;
             break;
         }
     }
@@ -68,7 +76,7 @@ static void dropdown_proxy_onselect(uint16_t i, const DROPDOWN *UNUSED(dm)) {
     proxy_address[edit_proxy_ip.length] = 0;
 
     edit_proxy_port.data[edit_proxy_port.length] = 0;
-    settings.proxy_port                          = strtol((char *)edit_proxy_port.data, NULL, 0);
+    settings.proxy_port = strtol((char *)edit_proxy_port.data, NULL, 0);
 
     tox_settingschanged();
 }

--- a/src/ui/edits.c
+++ b/src/ui/edits.c
@@ -417,7 +417,7 @@ static void edit_search_onenter(EDIT *edit) {
         friend_add(data, length, (char *)"", 0);
         edit_setstr(&edit_search, (char *)"", 0);
     } else {
-        if (tox_thread_init && !tox_thread_error) {
+        if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
             /* Only change if we're logged in! */
             edit_setstr(&edit_add_id, data, length);
             edit_setstr(&edit_search, (char *)"", 0);

--- a/src/ui/edits.c
+++ b/src/ui/edits.c
@@ -417,7 +417,7 @@ static void edit_search_onenter(EDIT *edit) {
         friend_add(data, length, (char *)"", 0);
         edit_setstr(&edit_search, (char *)"", 0);
     } else {
-        if (tox_thread_init) {
+        if (tox_thread_init && !tox_thread_error) {
             /* Only change if we're logged in! */
             edit_setstr(&edit_add_id, data, length);
             edit_setstr(&edit_search, (char *)"", 0);

--- a/src/ui/switch.c
+++ b/src/ui/switch.c
@@ -100,11 +100,7 @@ bool switch_mwheel(UISWITCH *UNUSED(s), int UNUSED(height), double UNUSED(d), bo
 
 bool switch_mup(UISWITCH *s) {
     // ignore click when switch is disabled
-    if (s->disabled) {
-        s->mousedown = 0;
-        return 1;
-    }
-    if (s->mousedown) {
+    if (s->mousedown && !s->disabled) {
         if (s->mouseover) {
             s->switch_on = !s->switch_on;
             s->on_mup();
@@ -112,6 +108,7 @@ bool switch_mup(UISWITCH *s) {
         s->mousedown = 0;
         return 1;
     }
+    s->mousedown = 0;
     return 0;
 }
 

--- a/src/ui/switch.c
+++ b/src/ui/switch.c
@@ -99,6 +99,11 @@ bool switch_mwheel(UISWITCH *UNUSED(s), int UNUSED(height), double UNUSED(d), bo
 }
 
 bool switch_mup(UISWITCH *s) {
+    // ignore click when switch is disabled
+    if (s->disabled) {
+        s->mousedown = 0;
+        return 1;
+    }
     if (s->mousedown) {
         if (s->mouseover) {
             s->switch_on = !s->switch_on;

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -1058,7 +1058,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR cmd, int n
     /* delete tray icon */
     Shell_NotifyIcon(NIM_DELETE, &nid);
 
-    /* wait for threads to exit */
+    // wait for tox_thread to exit
     while (tox_thread_init) {
         yieldcpu(10);
     }

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -1005,7 +1005,7 @@ BREAK:
     }
 #endif
 
-    /* wait for threads to exit */
+    // wait for tox_thread to exit
     while (tox_thread_init) {
         yieldcpu(1);
     }


### PR DESCRIPTION
In case of an error in `init_toxcore()` currently `tox_thread_init`
is not set to `1` causing the thread calling `tox_settingschanged()` to wait forever in
[this loop](https://github.com/uTox/uTox/blob/1835eae7a96a1335f781308b0afa730ab3647483/src/tox.c#L211-L213).

There are two error situations, the first is simple, waiting for
password input before tox can connect. The second is fatal error when
utox is unable to create a tox instance. The last one was failing here.
It is now fixed by handling this case in an exctra condition in
`toxcore_thread()`.

I have also fixed the error condition in `init_toxcore()` to fail only
if `*tox == NULL`, the other parts of the condition make no sense.

Additionally the Toggle of the UDP button got inverted when setting a
proxy, this is fixed by updating the button at the same time when
updating the setting.

Also disabling the UDP button when enabling proxy makes sense to avoid
creating impossible config combination.

Finally in the error sitatuation a link is created from the "Not
Connected" message to the network tab to allow adjusting the settings
quickly.

fixes #544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/569)
<!-- Reviewable:end -->
