### PR TITLE
Refactor postmessages()

### DIFF
--- a/src/android/audio.c
+++ b/src/android/audio.c
@@ -286,7 +286,7 @@ void audio_end(int32_t call_index) { call[call_index] = 0; }
 void audio_detect(void) {
     createEngine();
     createAudioRecorder();
-    postmessage(AUDIO_IN_DEVICE, STR_AUDIO_IN_ANDROID, 1, (void *)(size_t)1);
+    postmessage_utox(AUDIO_IN_DEVICE, STR_AUDIO_IN_ANDROID, 1, (void *)(size_t)1);
 }
 
 bool audio_init(void *handle) {

--- a/src/android/main.c
+++ b/src/android/main.c
@@ -43,7 +43,7 @@ typedef struct {
     void *   data;
 } PIPING;
 
-void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data) {
+void postmessage_utox(UTOX_MSG msg, uint16_t param1, uint16_t param2, void *data) {
     PIPING piping = {.msg = msg, .param1 = param1, .param2 = param2, .data = data };
 
     write(pipefd[1], &piping, sizeof(PIPING));
@@ -754,7 +754,7 @@ static void android_main(struct android_app *state) {
                 }
             }
 
-            utox_message(piping.msg, piping.param1, piping.param2, piping.data);
+            utox_message_dispatch(piping.msg, piping.param1, piping.param2, piping.data);
         }
 
         ANativeWindow *win = (ANativeWindow *)windowN;

--- a/src/av/audio.c
+++ b/src/av/audio.c
@@ -3,6 +3,7 @@
 
 #include "../friend.h"
 #include "../tox.h"
+#include "../utox.h"
 
 static void utox_filter_audio_kill(Filter_Audio *filter_audio_handle) {
 #ifdef AUDIO_FILTERING
@@ -257,11 +258,11 @@ static void audio_in_init(void) {
         debug("uToxAudio:\tinput device list:\n");
         while (*audio_in_device_list) {
             debug("\t%s\n", audio_in_device_list);
-            postmessage(AUDIO_IN_DEVICE, UI_STRING_ID_INVALID, 0, (void *)audio_in_device_list);
+            postmessage_utox(AUDIO_IN_DEVICE, UI_STRING_ID_INVALID, 0, (void *)audio_in_device_list);
             audio_in_device_list += strlen(audio_in_device_list) + 1;
         }
     }
-    postmessage(AUDIO_IN_DEVICE, STR_AUDIO_IN_NONE, 0, NULL);
+    postmessage_utox(AUDIO_IN_DEVICE, STR_AUDIO_IN_NONE, 0, NULL);
     audio_detect(); /* Get audio devices for windows */
 }
 
@@ -278,7 +279,7 @@ static void audio_out_init(void) {
         debug("uToxAudio:\toutput device list:\n");
         while (*audio_out_device_list) {
             debug("\t%s\n", audio_out_device_list);
-            postmessage(AUDIO_OUT_DEVICE, 0, 0, (void *)audio_out_device_list);
+            postmessage_utox(AUDIO_OUT_DEVICE, 0, 0, (void *)audio_out_device_list);
             audio_out_device_list += strlen(audio_out_device_list) + 1;
         }
     }
@@ -796,7 +797,7 @@ void utox_audio_thread(void *args) {
     uint64_t time = get_time();
 
     if (time - g->last_recv_audio[peernumber] > (uint64_t)1 * 1000 * 1000 * 1000) {
-        postmessage(GROUP_UPDATE, groupnumber, peernumber, NULL);
+        postmessage_utox(GROUP_UPDATE, groupnumber, peernumber, NULL);
     }
 
     g->last_recv_audio[peernumber] = time;

--- a/src/av/utox_av.c
+++ b/src/av/utox_av.c
@@ -7,6 +7,8 @@
 #include "../friend.h"
 #include "../inline_video.h"
 #include "../tox.h"
+#include "../utox.h"
+
 #include "../util.h"
 
 bool toxav_thread_msg = 0;
@@ -175,7 +177,7 @@ void utox_av_ctrl_thread(void *args) {
                         TOXAV_ERR_BIT_RATE_SET bitrate_err = 0;
                         toxav_bit_rate_set(av, msg->param1, -1, 0, &bitrate_err);
                     }
-                    postmessage(AV_CLOSE_WINDOW, msg->param1, 0, NULL);
+                    postmessage_utox(AV_CLOSE_WINDOW, msg->param1, 0, NULL);
                     break;
                 }
 
@@ -251,7 +253,7 @@ static void utox_av_incoming_call(ToxAV *UNUSED(av), uint32_t friend_number, boo
     f->call_state_friend = (audio << 2 | video << 3 | audio << 4 | video << 5);
     debug("uTox AV:\tcall friend (%u) state for incoming call: %i\n", friend_number, f->call_state_friend);
     postmessage_utoxav(UTOXAV_INCOMING_CALL_PENDING, friend_number, 0, NULL);
-    postmessage(AV_CALL_INCOMING, friend_number, video, NULL);
+    postmessage_utox(AV_CALL_INCOMING, friend_number, video, NULL);
 }
 
 static void utox_av_remote_disconnect(ToxAV *UNUSED(av), int32_t friend_number) {
@@ -259,8 +261,8 @@ static void utox_av_remote_disconnect(ToxAV *UNUSED(av), int32_t friend_number) 
     postmessage_utoxav(UTOXAV_CALL_END, friend_number, 0, NULL);
     friend[friend_number].call_state_self   = 0;
     friend[friend_number].call_state_friend = 0;
-    postmessage(AV_CLOSE_WINDOW, friend_number + 1, 0, NULL);
-    postmessage(AV_CALL_DISCONNECTED, friend_number, 0, NULL);
+    postmessage_utox(AV_CLOSE_WINDOW, friend_number + 1, 0, NULL);
+    postmessage_utox(AV_CALL_DISCONNECTED, friend_number, 0, NULL);
 }
 
 void utox_av_local_disconnect(ToxAV *av, int32_t friend_number) {
@@ -292,9 +294,9 @@ void utox_av_local_disconnect(ToxAV *av, int32_t friend_number) {
     }
     friend[friend_number].call_state_self   = 0;
     friend[friend_number].call_state_friend = 0;
-    postmessage(AV_CLOSE_WINDOW, friend_number + 1, 0, NULL); /* TODO move all of this into a static function in that
+    postmessage_utox(AV_CLOSE_WINDOW, friend_number + 1, 0, NULL); /* TODO move all of this into a static function in that
                                                                  file !*/
-    postmessage(AV_CALL_DISCONNECTED, friend_number, 0, NULL);
+    postmessage_utox(AV_CALL_DISCONNECTED, friend_number, 0, NULL);
     postmessage_utoxav(UTOXAV_CALL_END, friend_number, 0, NULL);
 }
 
@@ -380,9 +382,9 @@ static void utox_av_incoming_frame_v(ToxAV *UNUSED(toxAV), uint32_t friend_numbe
         if (!inline_set_frame(width, height, size, frame->img)) {
             debug_error("uToxAV:\t error setting frame for inline video\n");
         }
-        postmessage(AV_INLINE_FRAME, friend_number, 0, NULL);
+        postmessage_utox(AV_INLINE_FRAME, friend_number, 0, NULL);
     } else {
-        postmessage(AV_VIDEO_FRAME, friend_number + 1, 0, (void *)frame);
+        postmessage_utox(AV_VIDEO_FRAME, friend_number + 1, 0, (void *)frame);
     }
 }
 
@@ -394,7 +396,7 @@ static void utox_audio_friend_accepted(ToxAV *av, uint32_t friend_number, uint32
         utox_av_local_call_control(av, friend_number, TOXAV_CALL_CONTROL_HIDE_VIDEO);
     }
     postmessage_utoxav(UTOXAV_OUTGOING_CALL_ACCEPTED, friend_number, 0, NULL);
-    postmessage(AV_CALL_ACCEPTED, friend_number, 0, NULL);
+    postmessage_utox(AV_CALL_ACCEPTED, friend_number, 0, NULL);
 }
 
 /** respond to a Audio Video state change call back from toxav */

--- a/src/av/video.c
+++ b/src/av/video.c
@@ -1,15 +1,15 @@
-// video.c
-#include <pthread.h>
-#include <vpx/vpx_codec.h>
-#include <vpx/vpx_image.h>
-
 #include "utox_av.h"
 
 #include "../friend.h"
 #include "../tox.h"
+#include "../utox.h"
+
 #include "../ui/dropdowns.h"
 #include "../util.h"
 
+#include <pthread.h>
+#include <vpx/vpx_codec.h>
+#include <vpx/vpx_image.h>
 
 static void *   video_device[16]     = { NULL }; /* TODO; magic number */
 static int16_t  video_device_count   = 0;
@@ -111,7 +111,7 @@ bool utox_video_change_device(uint16_t device_number) {
             close_video_device(video_device[video_device_current]);
             if (settings.video_preview) {
                 settings.video_preview = 0;
-                postmessage(AV_CLOSE_WINDOW, 0, 0, NULL);
+                postmessage_utox(AV_CLOSE_WINDOW, 0, 0, NULL);
             }
         }
         debug("uToxVideo:\tDisabled Video device (none)\n");
@@ -137,7 +137,7 @@ bool utox_video_change_device(uint16_t device_number) {
             debug_error("uToxVideo:\tError, unable to start new device...\n");
             if (settings.video_preview) {
                 settings.video_preview = 0;
-                postmessage(AV_CLOSE_WINDOW, 0, 0, NULL);
+                postmessage_utox(AV_CLOSE_WINDOW, 0, 0, NULL);
             }
 
             pthread_mutex_unlock(&video_thread_lock);
@@ -186,7 +186,7 @@ bool utox_video_stop(bool UNUSED(preview)) {
 
     video_active           = 0;
     settings.video_preview = 0;
-    postmessage(AV_CLOSE_WINDOW, 0, 0, NULL);
+    postmessage_utox(AV_CLOSE_WINDOW, 0, 0, NULL);
 
     video_device_stop();
     close_video_device(video_device[video_device_current]);
@@ -253,7 +253,7 @@ void utox_video_thread(void *args) {
                                 utox_video_frame.v, utox_video_frame.w, (utox_video_frame.w / 2),
                                 (utox_video_frame.w / 2), frame->img);
 
-                    postmessage(AV_VIDEO_FRAME, 0, 1, (void *)frame);
+                    postmessage_utox(AV_VIDEO_FRAME, 0, 1, (void *)frame);
                 }
 
                 size_t active_video_count = 0;

--- a/src/cocoa/interaction.m
+++ b/src/cocoa/interaction.m
@@ -9,6 +9,7 @@
 #include "../ui.h"
 #include "../ui/edit.h"
 #include "../util.h"
+#include "../utox.h"
 
 NSCursor *cursors[8];
 
@@ -987,7 +988,7 @@ void openfileavatar(void) {
             [alert runModal];
             [alert release];
         } else {
-            postmessage(SELF_AVATAR_SET, fsize, 0, file_data);
+            postmessage_utox(SELF_AVATAR_SET, fsize, 0, file_data);
         }
     }
 }

--- a/src/cocoa/main.m
+++ b/src/cocoa/main.m
@@ -3,6 +3,7 @@
 #include "../ui.h"
 #include "../ui/dropdowns.h"
 #include "../util.h"
+#include "../utox.h"
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
@@ -314,11 +315,11 @@ int resize_file(FILE *file, uint64_t size) {
     return err;
 }
 
-void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data) {
+void postmessage_utox(UTOX_MSG msg, uint16_t param1, uint16_t param2, void *data) {
     /* If you notice any data races, or interesting bugs that appear in OSX but not xlib,
      * replace async( with sync( */
     dispatch_async(dispatch_get_main_queue(), ^{
-            utox_message(msg, param1, param2, data);
+            utox_message_dispatch(msg, param1, param2, data);
             });
 }
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -5,6 +5,7 @@
 #include "main.h"
 #include "main_native.h"
 #include "tox.h"
+#include "utox.h"
 
 static struct tox3 {
     uint8_t *name;
@@ -441,7 +442,7 @@ static void dns_thread(void *data) {
 #endif
 FAIL:
 
-    postmessage(DNS_RESULT, success, 0, data);
+    postmessage_utox(DNS_RESULT, success, 0, data);
 }
 
 void dns_request(char *name, size_t length) {

--- a/src/flist.c
+++ b/src/flist.c
@@ -1,9 +1,9 @@
-// flist.c
-
 #include "flist.h"
+
 
 #include "theme.h"
 #include "util.h"
+#include "utox.h"
 
 #include "ui/buttons.h"
 #include "ui/contextmenu.h"
@@ -939,7 +939,7 @@ static void contextmenu_friend(uint8_t rcase) {
             panel_friend_settings.disabled = 1;
             settings.inline_video          = 1;
             f->video_inline                = 1;
-            postmessage(AV_CLOSE_WINDOW, f->number + 1, 0, NULL);
+            postmessage_utox(AV_CLOSE_WINDOW, f->number + 1, 0, NULL);
             break;
         }
         case 2: {

--- a/src/friend.c
+++ b/src/friend.c
@@ -3,6 +3,7 @@
 
 #include "flist.h"
 #include "util.h"
+#include "utox.h"
 
 FRIEND* get_friend(uint32_t friend_number){
     if (friend_number >= 512) {
@@ -204,7 +205,6 @@ void friend_set_alias(FRIEND *f, uint8_t *alias, uint16_t length) {
 void friend_sendimage(FRIEND *f, NATIVE_IMAGE *native_image, uint16_t width, uint16_t height, UTOX_IMAGE png_image,
                       size_t png_size) {
     message_add_type_image(&f->msg, 1, native_image, width, height, 0);
-    redraw();
 
     struct TOX_SEND_INLINE_MSG *tsim = malloc(sizeof(struct TOX_SEND_INLINE_MSG));
 
@@ -228,6 +228,7 @@ void friend_notify_msg(FRIEND *f, const char *msg, size_t msg_length) {
     size_t title_length = snprintf((char *)title, UTOX_FRIEND_NAME_LENGTH(f) + 25, "uTox new message from %.*s",
                                    (int)UTOX_FRIEND_NAME_LENGTH(f), UTOX_FRIEND_NAME(f));
 
+    postmessage_utox(FRIEND_MESSAGE, 0, 0, NULL);
     notify(title, title_length, msg, msg_length, f, 0);
 
     if (flist_get_selected()->data != f) {

--- a/src/main.h
+++ b/src/main.h
@@ -454,8 +454,6 @@ void flush_file(FILE *file);
 int ch_mod(uint8_t *file);
 void config_osdefaults(UTOX_SAVE *r);
 
-void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data);
-
 /** returns 0 if push to talk is enabled, and the button is up, else returns 1. */
 void init_ptt(void);
 bool get_ptt_key(void);

--- a/src/messages.c
+++ b/src/messages.c
@@ -8,6 +8,7 @@
 #include "main.h"
 #include "theme.h"
 #include "util.h"
+#include "utox.h"
 
 #include "ui/svg.h"
 #include "ui/text.h"
@@ -511,7 +512,7 @@ void messages_clear_receipt(MESSAGES *m, uint32_t receipt_number) {
                     }
                     free(data);
 
-                    postmessage(FRIEND_MESSAGE, 0, 0, NULL); /* Used to redraw the screen */
+                    postmessage_utox(FRIEND_MESSAGE_UPDATE, 0, 0, NULL); /* Used to redraw the screen */
                     pthread_mutex_unlock(&messages_lock);
                     return;
                 }
@@ -1590,7 +1591,7 @@ bool messages_char(uint32_t ch) {
             if (scroll->d < 0.0) {
                 scroll->d = 0.0;
             }
-            redraw();
+            // redraw();
             return 1;
         }
 
@@ -1600,7 +1601,7 @@ bool messages_char(uint32_t ch) {
             if (scroll->d > 1.0) {
                 scroll->d = 1.0;
             }
-            redraw();
+            // redraw();
             return 1;
         }
     }

--- a/src/tox.h
+++ b/src/tox.h
@@ -87,69 +87,6 @@ enum {
     TOX_GROUP_AUDIO_END,
 };
 
-/* uTox client thread messages (received by the client thread) */
-enum {
-    /* General core and networking messages */
-    TOX_DONE, // 0
-    DHT_CONNECTED,
-    DNS_RESULT,
-
-    /* OS interaction/integration messages*/
-    AUDIO_IN_DEVICE,
-    AUDIO_OUT_DEVICE,
-
-    /* Client/User Interface messages. */
-    REDRAW,
-    TOOLTIP_SHOW,
-    SELF_AVATAR_SET,
-    UPDATE_TRAY,
-    PROFILE_DID_LOAD,
-
-    /* File transfer messages */
-    FILE_SEND_NEW,
-    FILE_INCOMING_NEW, // 10
-    FILE_INCOMING_ACCEPT,
-    FILE_UPDATE_STATUS,
-    FILE_INLINE_IMAGE,
-
-    /* Friend interaction messages. */
-    /* Handshake */
-    FRIEND_ONLINE,
-    FRIEND_NAME,
-    FRIEND_STATUS_MESSAGE,
-    FRIEND_STATE,
-    FRIEND_AVATAR_SET,
-    FRIEND_AVATAR_UNSET,
-    /* Interactions */
-    FRIEND_TYPING, // 20
-    FRIEND_MESSAGE,
-    /* Adding and deleting */
-    FRIEND_INCOMING_REQUEST,
-    FRIEND_ACCEPT_REQUEST,
-    FRIEND_SEND_REQUEST,
-    FRIEND_REMOVE,
-
-    /* Audio & Video calls, */
-    AV_CALL_INCOMING,
-    AV_CALL_RINGING,
-    AV_CALL_ACCEPTED,
-    AV_CALL_DISCONNECTED,
-    AV_VIDEO_FRAME, // 30
-    AV_INLINE_FRAME,
-    AV_CLOSE_WINDOW,
-
-    /* Group interactions, commented out for the new groupchats (coming soon maybe?) */
-    GROUP_ADD,
-    GROUP_MESSAGE,
-    GROUP_PEER_ADD,
-    GROUP_PEER_DEL,
-    GROUP_PEER_NAME,
-    GROUP_TOPIC,
-    GROUP_AUDIO_START,
-    GROUP_AUDIO_END,
-    GROUP_UPDATE,
-};
-
 struct TOX_SEND_INLINE_MSG {
     size_t     image_size;
     UTOX_IMAGE image;

--- a/src/ui/tooltip.c
+++ b/src/ui/tooltip.c
@@ -4,6 +4,7 @@
 
 #include "../theme.h"
 #include "../tox.h"
+#include "../utox.h"
 
 static TOOLTIP tooltip;
 
@@ -25,7 +26,7 @@ static void calculate_pos_and_width(TOOLTIP *b, int *x, int *w) {
     }
 
     // Push away from the right border to fit.
-    if (*x + *w >= settings.window_width) {
+    if (*x + *w >= (int)settings.window_width) {
         *x -= *w;
     }
 }
@@ -123,7 +124,7 @@ void tooltip_show(void) {
 
     b->y      = mouse.y + TOOLTIP_YOFFSET;
     b->height = TOOLTIP_HEIGHT;
-    if (b->y + b->height >= settings.window_height) {
+    if (b->y + b->height >= (int)settings.window_height) {
         b->y -= (b->height + TOOLTIP_YOFFSET);
     }
     b->x     = mouse.x;
@@ -152,7 +153,7 @@ static void tooltip_thread(void *UNUSED(args)) {
         }
 
         if (get_time() > last_move_time) {
-            postmessage(TOOLTIP_SHOW, 0, 0, NULL);
+            postmessage_utox(TOOLTIP_SHOW, 0, 0, NULL);
             last_move_time = ~0;
         }
 

--- a/src/utox.c
+++ b/src/utox.c
@@ -325,7 +325,8 @@ void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param
             break;
         }
         case FRIEND_MESSAGE: {
-            native_notify_new(NULL, NULL); // Intentional fallthrough
+            // TODO implement notification
+            //native_notify_new(NULL, NULL); // Intentional fallthrough
         }
         case FRIEND_MESSAGE_UPDATE: {
             redraw();

--- a/src/utox.c
+++ b/src/utox.c
@@ -72,8 +72,8 @@ static void call_notify(FRIEND *f, uint8_t status) {
     friend_notify_msg(f, str->str, str->length);
 }
 
-void utox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void *data) {
-    switch (tox_message_id) {
+void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param2, void *data) {
+    switch (utox_msg_id) {
         /* General core and networking messages */
         case TOX_DONE: {
             /* Does nothing. */
@@ -325,6 +325,9 @@ void utox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void
             break;
         }
         case FRIEND_MESSAGE: {
+            native_notify_new(NULL, NULL); // Intentional fallthrough
+        }
+        case FRIEND_MESSAGE_UPDATE: {
             redraw();
             break;
         }

--- a/src/utox.h
+++ b/src/utox.h
@@ -3,6 +3,72 @@
 
 #include <inttypes.h>
 
-void utox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void *data);
+/* uTox client thread messages (received by the client thread) */
+typedef enum utox_msg_id {
+    /* General core and networking messages */
+    TOX_DONE, // 0
+    DHT_CONNECTED,
+    DNS_RESULT,
+
+    /* OS interaction/integration messages*/
+    AUDIO_IN_DEVICE,
+    AUDIO_OUT_DEVICE,
+
+    /* Client/User Interface messages. */
+    REDRAW,
+    TOOLTIP_SHOW,
+    SELF_AVATAR_SET,
+    UPDATE_TRAY,
+    PROFILE_DID_LOAD,
+
+    /* File transfer messages */
+    FILE_SEND_NEW,
+    FILE_INCOMING_NEW,
+    FILE_INCOMING_ACCEPT,
+    FILE_UPDATE_STATUS,
+    FILE_INLINE_IMAGE,
+
+    /* Friend interaction messages. */
+    /* Handshake */
+    FRIEND_ONLINE,
+    FRIEND_NAME,
+    FRIEND_STATUS_MESSAGE,
+    FRIEND_STATE,
+    FRIEND_AVATAR_SET,
+    FRIEND_AVATAR_UNSET,
+    /* Interactions */
+    FRIEND_TYPING,
+    FRIEND_MESSAGE,
+    FRIEND_MESSAGE_UPDATE,
+    /* Adding and deleting */
+    FRIEND_INCOMING_REQUEST,
+    FRIEND_ACCEPT_REQUEST,
+    FRIEND_SEND_REQUEST,
+    FRIEND_REMOVE,
+
+    /* Audio & Video calls, */
+    AV_CALL_INCOMING,
+    AV_CALL_RINGING,
+    AV_CALL_ACCEPTED,
+    AV_CALL_DISCONNECTED,
+    AV_VIDEO_FRAME,
+    AV_INLINE_FRAME,
+    AV_CLOSE_WINDOW,
+
+    /* Group interactions, commented out for the new groupchats (coming soon maybe?) */
+    GROUP_ADD,
+    GROUP_MESSAGE,
+    GROUP_PEER_ADD,
+    GROUP_PEER_DEL,
+    GROUP_PEER_NAME,
+    GROUP_TOPIC,
+    GROUP_AUDIO_START,
+    GROUP_AUDIO_END,
+    GROUP_UPDATE,
+} UTOX_MSG;
+
+void postmessage_utox(UTOX_MSG msg, uint16_t param1, uint16_t param2, void *data);
+
+void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param2, void *data);
 
 #endif

--- a/src/windows/audio.c
+++ b/src/windows/audio.c
@@ -119,7 +119,7 @@ void audio_detect(void) {
 
     debug("Windows:\tAudio frame count %u && Samples/s %lu\n", bufferFrameCount, pwfx->nSamplesPerSec);
 
-    // postmessage(AUDIO_IN_DEVICE, STR_AUDIO_IN_DEFAULT_LOOPBACK, 0, (void*)(size_t)1);
+    // postmessage_utox(AUDIO_IN_DEVICE, STR_AUDIO_IN_DEFAULT_LOOPBACK, 0, (void*)(size_t)1);
     // this has no effect on my system, so I'm commenting it out, if you can't get audio, try enabling this again!
     return;
 

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -5,6 +5,7 @@
 #include "../main.h"
 #include "../theme.h"
 #include "../tox.h"
+#include "../utox.h"
 
 #include "../av/utox_av.h"
 #include "../ui/dropdowns.h"
@@ -109,7 +110,7 @@ void openfileavatar(void) {
                 message[len++] = '\0';
                 MessageBox(NULL, (char *)message, NULL, MB_ICONWARNING);
             } else {
-                postmessage(SELF_AVATAR_SET, size, 0, file_data);
+                postmessage_utox(SELF_AVATAR_SET, size, 0, file_data);
                 break;
             }
         } else {
@@ -173,7 +174,7 @@ int native_to_utf8str(wchar_t *str_in, char *str_out, uint32_t max_size) {
     return WideCharToMultiByte(CP_UTF8, 0, str_in, -1, str_out, max_size, NULL, NULL);
 }
 
-void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data) {
+void postmessage_utox(UTOX_MSG msg, uint16_t param1, uint16_t param2, void *data) {
     PostMessage(hwnd, WM_TOX + (msg), ((param1) << 16) | (param2), (LPARAM)data);
 }
 
@@ -997,7 +998,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR cmd, int n
     hwnd = CreateWindowExW(0, classname, title, WS_OVERLAPPEDWINDOW, save->window_x, save->window_y, save->window_width,
                            save->window_height, NULL, NULL, hInstance, NULL);
 
-    // free(save);
 
     hdc_brush = GetStockObject(DC_BRUSH);
 
@@ -1468,7 +1468,7 @@ LRESULT CALLBACK WindowProc(HWND hwn, UINT msg, WPARAM wParam, LPARAM lParam) {
         }
 
         case WM_TOX ... WM_TOX + 128: {
-            utox_message(msg - WM_TOX, wParam >> 16, wParam, (void *)lParam);
+            utox_message_dispatch(msg - WM_TOX, wParam >> 16, wParam, (void *)lParam);
             return false;
         }
     }

--- a/src/xlib/event.c
+++ b/src/xlib/event.c
@@ -560,7 +560,7 @@ bool doevent(XEvent event) {
             if (ev->window == 0) {
                 void *data;
                 memcpy(&data, &ev->data.s[2], sizeof(void *));
-                utox_message(ev->message_type, ev->data.s[0], ev->data.s[1], data);
+                utox_message_dispatch(ev->message_type, ev->data.s[0], ev->data.s[1], data);
                 break;
             }
 

--- a/src/xlib/gtk.c
+++ b/src/xlib/gtk.c
@@ -2,6 +2,7 @@
 #include "../flist.h"
 #include "../friend.h"
 #include "../util.h"
+#include "../utox.h"
 
 #include <dlfcn.h>
 #include <stdbool.h>

--- a/src/xlib/gtk.c
+++ b/src/xlib/gtk.c
@@ -184,7 +184,7 @@ static void ugtk_openavatarthread(void *UNUSED(args)) {
             utoxGTK_dialog_run(message_dialog);
             utoxGTK_widget_destroy(message_dialog);
         } else {
-            postmessage(SELF_AVATAR_SET, size, 0, file_data);
+            postmessage_utox(SELF_AVATAR_SET, size, 0, file_data);
             break;
         }
     }
@@ -245,7 +245,7 @@ static void ugtk_savethread(void *args) {
                 utoxGTK_widget_destroy(dialog);
                 utoxGTK_main_iteration();
                 utoxGTK_widget_destroy(dialog);
-                postmessage(FILE_INCOMING_ACCEPT, file->friend_number, (file->file_number >> 16), path);
+                postmessage_utox(FILE_INCOMING_ACCEPT, file->friend_number, (file->file_number >> 16), path);
                 break;
             }
         } else if (result == GTK_RESPONSE_CANCEL) {

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -24,7 +24,7 @@ void setclipboard(void) {
     XSetSelectionOwner(display, XA_CLIPBOARD, window, CurrentTime);
 }
 
-void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data) {
+void postmessage_utox(UTOX_MSG msg, uint16_t param1, uint16_t param2, void *data) {
     XEvent event = {
         .xclient = {.window = 0, .type = ClientMessage, .message_type = msg, .format = 8, .data = {.s = { param1, param2 } } }
     };

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -7,6 +7,7 @@
 #include "../theme.h"
 #include "../ui/dropdowns.h"
 #include "../util.h"
+#include "../utox.h"
 
 bool hidden = false;
 


### PR DESCRIPTION
This change makes it more clear what needs to be done inside the
UI thread, vs what's allowed to be done by the toxcore thread.

In this case, redraw() must only be called from the UI thread.
While this is always the way it should have been, the addition
of the 2,3... windows each having their own drawing device
context removes the flexablity we could allow before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/590)
<!-- Reviewable:end -->
