### PR TITLE
configure version in one place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ set(PROJECT_VERSION_MINOR "11")
 set(PROJECT_VERSION_PATCH "1")
 set(PROJECT_VERSION
   "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+# make version available in C files
+configure_file(${uTox_SOURCE_DIR}/src/branding.h.in
+               ${uTox_SOURCE_DIR}/src/branding.h)
+configure_file(${uTox_SOURCE_DIR}/src/cocoa/Info.plist.in
+               ${uTox_SOURCE_DIR}/src/cocoa/Info.plist)
+configure_file(${uTox_SOURCE_DIR}/src/android/AndroidManifest.xml.in
+               ${uTox_SOURCE_DIR}/src/android/AndroidManifest.xml)
+
 
 
 set(CMAKE_C_STANDARD 99)

--- a/src/android/AndroidManifest.xml.in
+++ b/src/android/AndroidManifest.xml.in
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="tox.client.utox"
-        android:versionName="0.11.1"
+        android:versionName="@PROJECT_VERSION@"
         android:versionCode="3"> <!-- versionCode must int. inc for patches -->
 
     <!-- This is the platform API where NativeActivity was introduced. -->

--- a/src/branding.h
+++ b/src/branding.h
@@ -1,0 +1,21 @@
+/**
+ * uTox Versions and header information
+ *
+ * This file contains defines regarding uTox branding and version information
+ * It is a template from which cmake will generate branding.h
+ */
+
+#define TITLE "uTox"
+#define SUB_TITLE "(Alpha)"
+
+#define RELEASE_TITLE "GOLD MEMBERS"
+#define VERSION "0.11.1"
+#define VER_MAJOR 0
+#define VER_MINOR 11
+#define VER_PATCH 1
+#define UTOX_VERSION_NUMBER (VER_MAJOR * 1000 * 1000 + VER_MINOR * 1000 + VER_PATCH)
+
+// Defaults
+#define DEFAULT_NAME "uTox User"
+#define DEFAULT_STATUS "Toxing on uTox, from the future!"
+#define DEFAULT_SCALE 11

--- a/src/branding.h.in
+++ b/src/branding.h.in
@@ -1,0 +1,21 @@
+/**
+ * uTox Versions and header information
+ *
+ * This file contains defines regarding uTox branding and version information
+ * It is a template from which cmake will generate branding.h
+ */
+
+#define TITLE "uTox"
+#define SUB_TITLE "(Alpha)"
+
+#define RELEASE_TITLE "GOLD MEMBERS"
+#define VERSION "@PROJECT_VERSION@"
+#define VER_MAJOR @PROJECT_VERSION_MAJOR@
+#define VER_MINOR @PROJECT_VERSION_MINOR@
+#define VER_PATCH @PROJECT_VERSION_PATCH@
+#define UTOX_VERSION_NUMBER (VER_MAJOR * 1000 * 1000 + VER_MINOR * 1000 + VER_PATCH)
+
+// Defaults
+#define DEFAULT_NAME "uTox User"
+#define DEFAULT_STATUS "Toxing on uTox, from the future!"
+#define DEFAULT_SCALE 11

--- a/src/cocoa/Info.plist.in
+++ b/src/cocoa/Info.plist.in
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>org.utox.future</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>uTox</string>
+	<key>CFBundleDisplayName</key>
+	<string>uTox (Alpha)</string>
+	<key>CFBundleSpokenName</key>
+	<string>u Tox</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@PROJECT_VERSION@</string>
+	<key>CFBundleVersion</key>
+	<string>@PROJECT_VERSION@</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015-2017 Tox project. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>Tox</string>
+        	<key>CFBundleTypeRole</key>
+        	<string>Viewer</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>tox</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/src/main.h
+++ b/src/main.h
@@ -23,18 +23,7 @@
  * uTox Versions and header information
  *
  *********************************************************/
-#define TITLE "uTox"
-#define SUB_TITLE "(Alpha)"
-#define RELEASE_TITLE "GOLD MEMBERS"
-#define VERSION "0.11.1"
-#define VER_MAJOR 0
-#define VER_MINOR 11
-#define VER_PATCH 1
-#define UTOX_VERSION_NUMBER (VER_MAJOR * 1000 * 1000 + VER_MINOR * 1000 + VER_PATCH)
-// Defaults
-#define DEFAULT_NAME "uTox User"
-#define DEFAULT_STATUS "Toxing on uTox, from the future!"
-#define DEFAULT_SCALE 11
+#include "branding.h"
 
 /**********************************************************
  *


### PR DESCRIPTION
uses cmake's configure_file module to generate a header file based on version options.

This will probably cause problem with non-cmake builds, which are:

- [x] android

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/593)
<!-- Reviewable:end -->
