### PR TITLE
Warn instead of segv when the file status is too large.

### DIFF
--- a/src/utox.c
+++ b/src/utox.c
@@ -198,6 +198,7 @@ void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param
             break;
         }
         case FILE_INCOMING_NEW: {
+            debug_notice("Toxcore:\tNew incoming file %u from friend %u.\n", param2, param1);
             FILE_TRANSFER *file = data;
 
             FRIEND *f = get_friend(param1);
@@ -220,9 +221,16 @@ void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param
             break;
         }
         case FILE_UPDATE_STATUS: {
+            debug_notice("Toxcore:\tUpdating status for file %u to %u.\n", param2, param1);
             if (!data) {
                 break;
             }
+
+            if (param1 > UINT8_MAX) {
+                debug_error("Toxcore:\tTried setting a file transfer status to a ridiculous number. (%u)", param1);
+                break;
+            }
+
             FILE_TRANSFER *file = data;
 
             if (file->ui_data) {


### PR DESCRIPTION
I can consistently get uTox to segv without this patchwork solution. Still need to fix whatever's setting the file status to ~uint16_max.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/664)
<!-- Reviewable:end -->
