### PR TITLE
Decrease minimum width.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -50,8 +50,8 @@ typedef uint8_t *UTOX_IMAGE;
 
 #define BORDER 1
 #define CAPTION 26
-#define MAIN_WIDTH 1000
-#define MAIN_HEIGHT 600
+#define MAIN_WIDTH 800
+#define MAIN_HEIGHT 500
 
 //  fixes compile with apple headers
 /*** This breaks both android and Windows video... but it's needed to fix complation in clang (Cocoa & asan)


### PR DESCRIPTION
I like to have the uTox window as small as possible along the horizontal axis. A problem with this is that it cuts off the end of the nospam message. In my opinion that's fine as you can expand the window to read it the one time you need to.

I would like to make it even smaller horizontally, but at that point the Tox ID starts getting cut off and users might be confused by that.

![nospam](https://cloud.githubusercontent.com/assets/8304462/22263524/0c8ee5da-e275-11e6-969b-90534af7b7c9.png)

Fixes #663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/666)
<!-- Reviewable:end -->
