### PR TITLE
Fix a typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(FILTER_AUDIO)
     add_cflag("-DAUDIO_FILTERING")
 endif()
 
-option(UTOX_STATIC "Link uTox staticlly" OFF)
+option(UTOX_STATIC "Link uTox statically" OFF)
 if(UTOX_STATIC)
     add_cflag("-static")
 endif()


### PR DESCRIPTION
The word "staticlly" should be "statically".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/672)
<!-- Reviewable:end -->
