### PR TITLE
Fix chatlogs being set to read-only on Windows.

### DIFF
--- a/src/windows/filesys.c
+++ b/src/windows/filesys.c
@@ -14,6 +14,7 @@ static FILE* get_file(wchar_t path[UTOX_FILE_NAME_LENGTH], UTOX_FILE_OPTS opts) 
         rw |= GENERIC_READ;
         mode[0] = 'r';
         if (opts & UTOX_FILE_OPTS_WRITE || opts & UTOX_FILE_OPTS_APPEND) {
+            rw |= GENERIC_WRITE;
             create = OPEN_ALWAYS;
         }
     } else if (opts & UTOX_FILE_OPTS_APPEND) {


### PR DESCRIPTION
Might want to consider pushing a hotfix release with this or we're leaving chatlogs on Windows broken for another 3 weeks.

Fixes #682 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/704)
<!-- Reviewable:end -->
