### PR TITLE
Make fread more samey across uTox.

### DIFF
--- a/src/avatar.c
+++ b/src/avatar.c
@@ -54,18 +54,18 @@ static uint8_t *load_img_data(char hexid[TOX_PUBLIC_KEY_SIZE * 2], size_t *out_s
         return NULL;
     }
 
-    if (fread(data, size, 1, fp) == 1) {
+    if (fread(data, size, 1, fp) != 1) {
+        LOG_WARN("Avatar", "Could not read from open file: %s\n", name);
         fclose(fp);
-        if (out_size) {
-            *out_size = size;
-        }
-        return data;
+        free(data);
+        return NULL;
     }
 
-    LOG_WARN("Avatar", "Could not read from open file: %s\n", name);
     fclose(fp);
-    free(data);
-    return NULL;
+    if (out_size) {
+        *out_size = size;
+    }
+    return data;
 }
 
 bool avatar_delete(char hexid[TOX_PUBLIC_KEY_SIZE * 2]) {

--- a/src/chatlog.c
+++ b/src/chatlog.c
@@ -248,7 +248,7 @@ void utox_export_chatlog(char hex[TOX_PUBLIC_KEY_SIZE * 2], FILE *dest_file) {
     FILE *file = chatlog_get_file(hex, false);
 
     LOG_FILE_MSG_HEADER header;
-    while (1 == fread(&header, sizeof(header), 1, file)) {
+    while (fread(&header, sizeof(header), 1, file) == 1) {
         char c;
         /* Write Author */
         fwrite("<", 1, 1, dest_file);

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -226,7 +226,7 @@ static bool ft_find_resumeable(FILE_TRANSFER *ft) {
     }
 
     FILE_TRANSFER resume_file;
-    fread(&resume_file, 1, size, resume_disk);
+    fread(&resume_file, size, 1, resume_disk);
     fclose(resume_disk);
 
     if (!resume_file.resumeable
@@ -1112,11 +1112,10 @@ static void outgoing_file_callback_chunk(Tox *tox, uint32_t friend_number, uint3
         if (ft->via.file) {
             uint8_t buffer[length];
             fseeko(ft->via.file, position, SEEK_SET);
-            size_t read_size = fread(buffer, 1, length, ft->via.file);
-            if (read_size != length) {
+            if (fread(buffer, length, 1, ft->via.file) != 1) {
                 LOG_ERR("FileTransfer", "ERROR READING FILE! (%u & %u)" , friend_number, file_number);
-                LOG_INFO("FileTransfer", "Size (%lu), Position (%lu), Length(%lu), Read_size (%lu), size_transferred (%lu).\n",
-                   ft->target_size, position, length, read_size, ft->current_size);
+                LOG_INFO("FileTransfer", "Size (%lu), Position (%lu), Length(%lu), size_transferred (%lu).\n",
+                         ft->target_size, position, length, ft->current_size);
                 ft_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
                 return;
             }

--- a/src/main.c
+++ b/src/main.c
@@ -109,6 +109,7 @@ UTOX_SAVE *utox_data_load_utox(void) {
 
     if (fread(save, size, 1, fp) != 1) {
         LOG_ERR(__FILE__, "Could not read save file");
+
         fclose(fp);
         free(save);
         return NULL;

--- a/src/theme.c
+++ b/src/theme.c
@@ -677,7 +677,7 @@ static uint8_t *utox_data_load_custom_theme(size_t *out) {
         return NULL;
     }
 
-    if (fread(data, 1, *out, fp) != 1) {
+    if (fread(data, *out, 1, fp) != 1) {
         LOG_ERR("Theme", "Could not read custom theme from file");
         fclose(fp);
         free(data);


### PR DESCRIPTION
This fixes uTox not being able to read custom themes.

(`if (fread(data, 1, *out, fp) != 1) {` in `theme.c` tried to read `*out` elements of size 1 and compares the number of bytes read with 1 to decide if we could load the theme. (This only works if the theme file is 1 byte.))

This PR modifies all `fread` calls in uTox to try to read 1 element of whatever size we want instead of size elements of size 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/725)
<!-- Reviewable:end -->
