### PR TITLE
Fix utf8 copy-paste everywhere.

### DIFF
--- a/src/filesys.c
+++ b/src/filesys.c
@@ -14,19 +14,16 @@ bool utox_move_file(const uint8_t *current_name, const uint8_t *new_name) {
 }
 
 void *file_raw(char *path, uint32_t *size) {
-    FILE *file;
-    char *data;
-    int   len;
-
-    file = fopen(path, "rb");
+    FILE *file = fopen(path, "rb");
     if (!file) {
         // LOG_TRACE(__FILE__, "File not found (%s)" , path);
         return NULL;
     }
 
     fseek(file, 0, SEEK_END);
-    len  = ftell(file);
-    data = malloc(len);
+    int len = ftell(file);
+
+    char *data = calloc(1, len);
     if (!data) {
         fclose(file);
         return NULL;
@@ -43,10 +40,9 @@ void *file_raw(char *path, uint32_t *size) {
 
     fclose(file);
 
-    // LOG_TRACE(__FILE__, "Read %u bytes (%s)" , len, path);
-
     if (size) {
         *size = len;
     }
+
     return data;
 }

--- a/src/main_native.h
+++ b/src/main_native.h
@@ -95,6 +95,7 @@ bool native_move_file(const uint8_t *current_name, const uint8_t *new_name);
 void init_ptt(void);
 bool get_ptt_key(void); // Never used. Remove?
 bool set_ptt_key(void); // Never used. Remove?
+// Returns a bool indicating whether you should send audio or not.
 bool check_ptt_key(void);
 void exit_ptt(void);
 

--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -773,12 +773,16 @@ void edit_paste(char *data, int length, bool select) {
     const int maxlen = active_edit->maxlength - active_edit->length + edit_sel.length;
     int newlen = 0, i = 0;
     while (i < length) {
-        uint8_t len = utf8_len(data + i);
-        // Ignore and strip these control characters.
-        if ((((!active_edit->multiline || data[i] != '\n')                               // not multiline or '\n'
-              && data[i] <= 0x1F)                                                        // and is a control char
-             || data[i] == 0x7F)                                                         // or is delete
-            || (len == 2 && (uint8_t)data[i] == 0xC2 && (uint8_t)data[i + 1] <= 0xBF)) { // or is utf8
+        const uint8_t len = utf8_len(data + i);
+
+        const bool not_linebreak = !active_edit->multiline || data[i] != '\n';
+        const bool is_multibyte = len > 1;
+        const bool is_control_char = is_multibyte ? (uint8_t)data[i] == 0xC2 && (uint8_t)data[i + 1] <= 0x9F
+                                                  : data[i] <= 0x1F && not_linebreak;
+        const bool is_delete = data[i] == 0x7F;
+
+        if (is_delete || is_control_char) {
+            // Ignore these characters
         } else {
             if (newlen + len > maxlen) {
                 break;

--- a/src/windows/main.h
+++ b/src/windows/main.h
@@ -18,7 +18,7 @@
 #define WINVER 0x410
 #endif
 
-#include <inttypes.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -90,7 +90,6 @@ typedef struct native_image {
     // stretch mode used when stretching this image, either
     // COLORONCOLOR(ugly and fast), or HALFTONE(prettier and slower)
     int stretch_mode;
-
 } NATIVE_IMAGE;
 
 // static char save_path[280];


### PR DESCRIPTION
This was going to be a Windows cleanup PR, but it got away from me.. 
The file you'll want to focus on is ui/edit.c. 

I also (unrelated to fixing the copy-paste) changed the 2-byte utf8 condition from `(uint8_t)data[i] == 0xC2 && (uint8_t)data[i + 1] <= 0xBF)` to ending with `<= 0x9F` since as far as I can see, `0xBF` would include a bunch of valid utf8 characters.

Fixes #583

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/727)
<!-- Reviewable:end -->
