### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/av/CMakeLists.txt
+++ b/src/av/CMakeLists.txt
@@ -7,7 +7,11 @@ add_library(utoxAV STATIC
     )
 
 if(NOT APPLE)
+if(WIN32)
+    target_link_libraries(utoxAV OpenAL32)
+else()
     target_link_libraries(utoxAV openal)
+endif()
 endif()
 
 if(FILTER_AUDIO)

--- a/src/av/CMakeLists.txt
+++ b/src/av/CMakeLists.txt
@@ -6,12 +6,11 @@ add_library(utoxAV STATIC
     video.c
     )
 
-if(NOT APPLE)
-if(WIN32)
+if(APPLE)
+elseif(WIN32)
     target_link_libraries(utoxAV OpenAL32)
 else()
     target_link_libraries(utoxAV openal)
-endif()
 endif()
 
 if(FILTER_AUDIO)


### PR DESCRIPTION
openal-soft generates always OpenAL32 when builds for Windows.

https://cmake.org/cmake/help/v3.5/variable/WIN32.html
>WIN32
>True on Windows systems, including Win64.
>Set to true when the target system is Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/731)
<!-- Reviewable:end -->
