### PR TITLE
Log to stderr on Windows and Xlib.

### DIFF
--- a/src/windows/logging.h
+++ b/src/windows/logging.h
@@ -1,3 +1,3 @@
 #include <stdio.h>
 
-#define debug(...) (printf(__VA_ARGS__) & fflush(stdout))
+#define debug(...) (void)(fprintf(stderr, __VA_ARGS__) && fflush(stderr))

--- a/src/xlib/logging.h
+++ b/src/xlib/logging.h
@@ -1,3 +1,3 @@
 #include <stdio.h>
 
-#define debug(...) printf(__VA_ARGS__)
+#define debug(...) fprintf(stderr, __VA_ARGS__)


### PR DESCRIPTION
Also silences a ton of warnings re: unused computed value when compiling on Windows.
(That's what the cast to void does.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/736)
<!-- Reviewable:end -->
