### PR TITLE
Fix Windows warnings and exporting chatlogs as plaintext on Windows.

### DIFF
--- a/src/layout/notify.c
+++ b/src/layout/notify.c
@@ -78,6 +78,7 @@ BUTTON button_notify_two = {
 static void btn_notify_three_mup(void) {
     LOG_ERR("Layout Notify", "Button 3 pressed");
 }
+
 BUTTON button_notify_three = {
     // .bm  = BM_SBUTTON,
     .update = button_setcolors_success,
@@ -85,6 +86,7 @@ BUTTON button_notify_three = {
     .nodraw = false,
 };
 
+#if 0
 static void btn_move_window_mdn(void) {
     LOG_NOTE(__FILE__, "button move down\n");
     btn_move_window_down = true;
@@ -94,6 +96,7 @@ static void btn_move_window_mup(void) {
     LOG_NOTE(__FILE__, "button move up\n");
     btn_move_window_down = false;
 }
+#endif
 
 static void btn_move_notify_mup(void) {
     LOG_NOTE(__FILE__, "button tween\n");

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,7 @@ uint8_t *utox_data_load_tox(size_t *size) {
     for (uint8_t i = 0; i < 4; i++) {
         size_t length = 0;
 
-        const FILE *fp = native_get_file(name[i], &length, UTOX_FILE_OPTS_READ);
+        FILE *fp = native_get_file(name[i], &length, UTOX_FILE_OPTS_READ);
         if (fp == NULL) {
             continue;
         }
@@ -95,13 +95,13 @@ bool utox_data_save_utox(UTOX_SAVE *data, size_t size) {
 
 UTOX_SAVE *utox_data_load_utox(void) {
     size_t size = 0;
-    const FILE *fp = native_get_file((uint8_t *)"utox_save", &size, UTOX_FILE_OPTS_READ);
+    FILE *fp = native_get_file((uint8_t *)"utox_save", &size, UTOX_FILE_OPTS_READ);
 
     if (fp == NULL) {
         return NULL;
     }
 
-    const UTOX_SAVE *save = calloc(1, size + 1);
+    UTOX_SAVE *save = calloc(1, size + 1);
     if (save == NULL) {
         fclose(fp);
         return NULL;

--- a/src/messages.c
+++ b/src/messages.c
@@ -1551,7 +1551,7 @@ int messages_selection(PANEL *panel, void *buffer, uint32_t len, bool names) {
 
         if (names && (i != m->sel_start_msg || m->sel_start_position == 0)) {
             if (m->is_groupchat) {
-                memcpy(p, msg->via.grp.msg, msg->via.grp.author_length);
+                memcpy(p, msg->via.grp.author, msg->via.grp.author_length);
                 p += msg->via.grp.author_length;
                 len -= msg->via.grp.author_length;
             } else {

--- a/src/messages.c
+++ b/src/messages.c
@@ -1472,7 +1472,7 @@ bool messages_mright(PANEL *panel) {
 
         case MSG_TYPE_TEXT:
         case MSG_TYPE_ACTION_TEXT: {
-            const static UTOX_I18N_STR menu_copy[] = { STR_COPY, STR_COPY_WITH_NAMES };
+            static UTOX_I18N_STR menu_copy[] = { STR_COPY, STR_COPY_WITH_NAMES };
             contextmenu_new(COUNTOF(menu_copy), menu_copy, contextmenu_messages_onselect);
             return true;
         }
@@ -1551,7 +1551,7 @@ int messages_selection(PANEL *panel, void *buffer, uint32_t len, bool names) {
 
         if (names && (i != m->sel_start_msg || m->sel_start_position == 0)) {
             if (m->is_groupchat) {
-                memcpy(p, msg->via.grp.msg[0], msg->via.grp.author_length);
+                memcpy(p, msg->via.grp.msg, msg->via.grp.author_length);
                 p += msg->via.grp.author_length;
                 len -= msg->via.grp.author_length;
             } else {

--- a/src/ui/contextmenu.c
+++ b/src/ui/contextmenu.c
@@ -144,7 +144,7 @@ bool contextmenu_mleave(void) {
     return 0;
 }
 
-void contextmenu_new_ex(uint8_t count, const void *userdata, void (*onselect)(uint8_t),
+void contextmenu_new_ex(uint8_t count, void *userdata, void (*onselect)(uint8_t),
                         STRING *(*ondisplay)(uint8_t, const CONTEXTMENU *)) {
     CONTEXTMENU *b = &context_menu;
 
@@ -156,7 +156,7 @@ void contextmenu_new_ex(uint8_t count, const void *userdata, void (*onselect)(ui
     b->x     = mouse.x;
     b->width = CONTEXT_WIDTH;
 
-    b->open      = 1;
+    b->open      = true;
     b->count     = count;
     b->over      = 0xFF;
     b->onselect  = onselect;
@@ -168,6 +168,6 @@ static STRING *contextmenu_localized_ondisplay(uint8_t i, const CONTEXTMENU *cm)
     return SPTRFORLANG(LANG, ((UTOX_I18N_STR *)cm->userdata)[i]);
 }
 
-void contextmenu_new(uint8_t count, const UTOX_I18N_STR *menu_string_ids, void (*onselect)(uint8_t)) {
+void contextmenu_new(uint8_t count, UTOX_I18N_STR *menu_string_ids, void (*onselect)(uint8_t)) {
     contextmenu_new_ex(count, menu_string_ids, onselect, contextmenu_localized_ondisplay);
 }

--- a/src/ui/contextmenu.h
+++ b/src/ui/contextmenu.h
@@ -21,8 +21,8 @@ bool contextmenu_mdown(void);
 bool contextmenu_mup(void);
 bool contextmenu_mleave(void);
 
-void contextmenu_new(uint8_t count, const UTOX_I18N_STR *menu_string_ids, void (*onselect)(uint8_t));
-void contextmenu_new_ex(uint8_t count, const void *userdata, void (*onselect)(uint8_t),
+void contextmenu_new(uint8_t count, UTOX_I18N_STR *menu_string_ids, void (*onselect)(uint8_t));
+void contextmenu_new_ex(uint8_t count, void *userdata, void (*onselect)(uint8_t),
                         STRING *(*ondisplay)(uint8_t, const CONTEXTMENU *));
 
 #endif

--- a/src/windows/dnd.c
+++ b/src/windows/dnd.c
@@ -91,16 +91,16 @@ HRESULT __stdcall dnd_Drop(IDropTarget *UNUSED(lpMyObj), IDataObject *pDataObjec
                 return 0;
             }
 
-            uint8_t *path = calloc(1, UTOX_FILE_NAME_LENGTH * sizeof(uint8_t));
+            char *path = calloc(1, UTOX_FILE_NAME_LENGTH);
             if (!path) {
                 LOG_ERR("WINDND", "Unable to alloc for UTOX_MSG_FT");
                 free(msg);
                 return 0;
             }
 
-            DragQueryFile(h, i, (char *)path, UTOX_FILE_NAME_LENGTH);
+            DragQueryFile(h, i, path, UTOX_FILE_NAME_LENGTH);
 
-            msg->file = fopen((char *)path, "rb");
+            msg->file = fopen(path, "rb");
             if (!msg->file) {
                 LOG_ERR("WINDND", "Unable to read file %s" , path);
                 free(msg);
@@ -108,7 +108,7 @@ HRESULT __stdcall dnd_Drop(IDropTarget *UNUSED(lpMyObj), IDataObject *pDataObjec
                 return 0;
             }
 
-            msg->name = path;
+            msg->name = (uint8_t *)path;
             postmessage_toxcore(TOX_FILE_SEND_NEW, ((FRIEND*)flist_get_selected()->data)->number, 0, msg);
             LOG_INFO("WINDND", "File number %i sent!" , i);
         }

--- a/src/windows/dnd.c
+++ b/src/windows/dnd.c
@@ -91,16 +91,16 @@ HRESULT __stdcall dnd_Drop(IDropTarget *UNUSED(lpMyObj), IDataObject *pDataObjec
                 return 0;
             }
 
-            uint8_t *path = calloc(UTOX_FILE_NAME_LENGTH, sizeof(uint8_t));
+            uint8_t *path = calloc(1, UTOX_FILE_NAME_LENGTH * sizeof(uint8_t));
             if (!path) {
                 LOG_ERR("WINDND", "Unable to alloc for UTOX_MSG_FT");
                 free(msg);
                 return 0;
             }
 
-            DragQueryFile(h, i, path, UTOX_FILE_NAME_LENGTH);
+            DragQueryFile(h, i, (char *)path, UTOX_FILE_NAME_LENGTH);
 
-            msg->file = fopen(path, "rb");
+            msg->file = fopen((char *)path, "rb");
             if (!msg->file) {
                 LOG_ERR("WINDND", "Unable to read file %s" , path);
                 free(msg);

--- a/src/windows/drawing.c
+++ b/src/windows/drawing.c
@@ -134,15 +134,16 @@ void draw_image(const NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_
 }
 
 void draw_inline_image(uint8_t *img_data, size_t UNUSED(size), uint16_t w, uint16_t h, int x, int y) {
-
-    BITMAPINFO bmi = {.bmiHeader = {
-                          .biSize        = sizeof(BITMAPINFOHEADER),
-                          .biWidth       = w,
-                          .biHeight      = -h,
-                          .biPlanes      = 1,
-                          .biBitCount    = 32,
-                          .biCompression = BI_RGB,
-                      } };
+    BITMAPINFO bmi = {
+        .bmiHeader = {
+            .biSize        = sizeof(BITMAPINFOHEADER),
+            .biWidth       = w,
+            .biHeight      = -h,
+            .biPlanes      = 1,
+            .biBitCount    = 32,
+            .biCompression = BI_RGB,
+            }
+        };
 
     SetDIBitsToDevice(curr->draw_DC, x, y, w, h, 0, 0, 0, h, img_data, &bmi, DIB_RGB_COLORS);
 }

--- a/src/windows/filesys.c
+++ b/src/windows/filesys.c
@@ -87,7 +87,9 @@ FILE *native_get_file(const uint8_t *name, size_t *size, UTOX_FILE_OPTS opts) {
         }
     }
 
-    snprintf((char *)path + strlen((char *)path), UTOX_FILE_NAME_LENGTH - strlen((char *)path), "/%s", (char *)name);
+    snprintf((char *)path + strlen((char *)path), UTOX_FILE_NAME_LENGTH - strlen((char *)path), "/%s", (char *)tmp_path);
+
+    free(tmp_path);
 
     for (size_t i = 0; path[i] != '\0'; ++i) {
         if (path[i] == '/') {

--- a/src/windows/filesys.c
+++ b/src/windows/filesys.c
@@ -44,8 +44,8 @@ FILE *native_get_file(const uint8_t *name, size_t *size, UTOX_FILE_OPTS opts) {
     if (settings.portable_mode) {
         strcpy((char *)path, portable_mode_save_path);
     } else {
-        if (FAILED(SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, path))) {
-            if (FAILED(SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, path))) {
+        if (FAILED(SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, (char *)path))) {
+            if (FAILED(SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, (char *)path))) {
                 strcpy((char *)path, portable_mode_save_path);
             }
         }
@@ -66,12 +66,19 @@ FILE *native_get_file(const uint8_t *name, size_t *size, UTOX_FILE_OPTS opts) {
         return NULL;
     }
 
+    uint8_t *tmp_path = calloc(1, strlen((char *)name) + 1);
+    strcpy((char *)tmp_path, (char *)name);
+
     // Append the subfolder to the path and remove it from the name.
-    for (char *folder_divider = strstr(name, "/"); folder_divider != NULL; folder_divider = strstr(name, "/")) {
+    for (char *folder_divider = strstr((char *)tmp_path, "/");
+         folder_divider != NULL;
+         folder_divider = strstr((char *)tmp_path, "/"))
+    {
         ++folder_divider; // Skip over the / we're pointing to.
-        snprintf((char *)path + strlen((char *)path), strlen(name) - strlen(folder_divider), name);
-        char *new_name = name + strlen(name) - strlen(folder_divider);
-        name = new_name;
+        snprintf((char *)path + strlen((char *)path), strlen((char *)tmp_path) - strlen(folder_divider),
+                 (char *)tmp_path);
+        uint8_t *new_path = tmp_path + strlen((char *)tmp_path) - strlen(folder_divider);
+        tmp_path = new_path;
     }
 
     if (opts & UTOX_FILE_OPTS_WRITE || opts & UTOX_FILE_OPTS_MKDIR) {
@@ -89,10 +96,10 @@ FILE *native_get_file(const uint8_t *name, size_t *size, UTOX_FILE_OPTS opts) {
     }
 
     wchar_t wide[UTOX_FILE_NAME_LENGTH] = { 0 };
-    MultiByteToWideChar(CP_UTF8, 0, path, strlen((char *)path), wide, UTOX_FILE_NAME_LENGTH);
+    MultiByteToWideChar(CP_UTF8, 0, (char *)path, strlen((char *)path), wide, UTOX_FILE_NAME_LENGTH);
 
     if (opts == UTOX_FILE_OPTS_DELETE) {
-        if (!DeleteFile(path)) {
+        if (!DeleteFile((char *)path)) {
             LOG_ERR("WinFilesys", "Could not delete file: %s - Error: %d" , path, GetLastError());
         }
         return NULL;
@@ -133,7 +140,7 @@ bool native_create_dir(const uint8_t *filepath) {
         }
     }
 
-    const int error = SHCreateDirectoryEx(NULL, path, NULL);
+    const int error = SHCreateDirectoryEx(NULL, (char *)path, NULL);
     switch(error) {
         case ERROR_SUCCESS:
         case ERROR_FILE_EXISTS:
@@ -201,5 +208,5 @@ bool native_move_file(const uint8_t *current_name, const uint8_t *new_name) {
         return false;
     }
 
-    return MoveFile(current_name, new_name);
+    return MoveFile((char *)current_name, (char *)new_name);
 }

--- a/src/windows/main.7.c
+++ b/src/windows/main.7.c
@@ -40,7 +40,7 @@ void native_export_chatlog_init(uint32_t friend_number) {
     if (GetSaveFileName(&ofn)) {
         FILE *file = fopen(path, "wb");
         if (file) {
-            utox_export_chatlog(friend_number, file);
+            utox_export_chatlog(get_friend(friend_number)->id_str, file);
         } else {
             LOG_ERR(__FILE__, "Opening file %s failed", path);
         }

--- a/src/windows/main.XP.c
+++ b/src/windows/main.XP.c
@@ -35,7 +35,7 @@ void native_export_chatlog_init(uint32_t friend_number) {
         // TODO: native_get_file instead of fopen.
         FILE *file = fopen(path, "wb");
         if (file) {
-            utox_export_chatlog(friend_number, file);
+            utox_export_chatlog(get_friend(friend_number)->id_str, file);
         } else {
             LOG_ERR(__FILE__, "Opening file %s failed", path);
         }

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -804,8 +804,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
         char         path[MAX_PATH];
         int          len = GetModuleFileName(hModule, path, MAX_PATH);
         unsigned int i;
-        for (i = len - 1; path[i] != '\\'; --i)
-            ;
+        for (i = len - 1; path[i] != '\\'; --i) {
+            // Do nothing until we reach the folder separator.
+        }
         path[i] = 0;
         SetCurrentDirectory(path);
         strcpy(portable_mode_save_path, (char *)path);
@@ -889,7 +890,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
     }
 
     if (*cmd) {
-        int len = strlen(cmd);
+        const int len = strlen(cmd);
         do_tox_url((uint8_t *)cmd, len);
     }
 

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -43,11 +43,11 @@ bool  havefocus;
  * Returns: number of chars writen, or 0 on failure.
  *
  */
-static int utf8tonative(char *str, wchar_t *out, int length) {
+static int utf8tonative(const char *str, wchar_t *out, int length) {
     return MultiByteToWideChar(CP_UTF8, 0, (char *)str, length, out, length);
 }
 
-static int utf8_to_nativestr(char *str, wchar_t *out, int length) {
+static int utf8_to_nativestr(const char *str, wchar_t *out, int length) {
     /* must be null terminated string                   ↓ */
     return MultiByteToWideChar(CP_UTF8, 0, (char *)str, -1, out, length);
 }
@@ -122,7 +122,7 @@ void openfileavatar(void) {
             } else if (size > UTOX_AVATAR_MAX_DATA_LENGTH) {
                 free(file_data);
                 char message[1024];
-                if (sizeof(message) < SLEN(AVATAR_TOO_LARGE_MAX_SIZE_IS) + 16) {
+                if (sizeof(message) < (unsigned)SLEN(AVATAR_TOO_LARGE_MAX_SIZE_IS) + 16) {
                     debug("error: AVATAR_TOO_LARGE message is larger than allocated buffer(%"PRIu64" bytes)\n",
                           sizeof(message));
                     break;
@@ -723,7 +723,7 @@ static void cursors_init(void) {
 
 static bool auto_update(PSTR cmd) {
     char path[MAX_PATH + 20];
-    int  len = GetModuleFileName(NULL, path, MAX_PATH);
+    unsigned len = GetModuleFileName(NULL, path, MAX_PATH);
 
     /* Is the uTox exe named like the updater one. */
     char *file = path + len - (sizeof("uTox.exe") - 1);
@@ -753,22 +753,28 @@ static bool auto_update(PSTR cmd) {
  * also handles call from other apps.
  */
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cmd, int nCmdShow) {
-
     pthread_mutex_init(&messages_lock, NULL);
 
     /* if opened with argument, check if uTox is already open and pass the argument to the existing process */
     HANDLE utox_mutex = CreateMutex(NULL, 0, TITLE);
 
     if (!utox_mutex) {
-        return false;
+        return 0;
     }
+
     if (GetLastError() == ERROR_ALREADY_EXISTS) {
         HWND window = FindWindow(TITLE, NULL);
+
         if (window) {
-            COPYDATASTRUCT data = {.cbData = strlen(cmd), .lpData = cmd };
+            COPYDATASTRUCT data = {
+                .cbData = strlen(cmd),
+                .lpData = cmd
+            };
+
             SendMessage(window, WM_COPYDATA, (WPARAM)hInstance, (LPARAM)&data);
         }
-        return false;
+
+        return 0;
     }
 
     /* Process argc/v the backwards (read: windows) way. */
@@ -778,7 +784,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
 
     if (NULL == argv) {
         LOG_TRACE(__FILE__, "CommandLineToArgvA failed" );
-        return true;
+        return 0;
     }
 
     bool   theme_was_set_on_argv;
@@ -789,14 +795,18 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
     parse_args(argc, argv, &skip_updater, &from_updater, &theme_was_set_on_argv,
                &should_launch_at_startup, &set_show_window );
 
+    // Free memory allocated by CommandLineToArgvA
+    GlobalFree(argv);
+
     if (settings.portable_mode == true) {
         /* force the working directory if opened with portable command */
         HMODULE      hModule = GetModuleHandle(NULL);
         char         path[MAX_PATH];
         int          len = GetModuleFileName(hModule, path, MAX_PATH);
         unsigned int i;
-        for (i = (len - 1); path[i] != '\\'; --i);
-        path[i] = 0; //!
+        for (i = len - 1; path[i] != '\\'; --i)
+            ;
+        path[i] = 0;
         SetCurrentDirectory(path);
         strcpy(portable_mode_save_path, (char *)path);
     }
@@ -821,9 +831,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
         LOG_TRACE(__FILE__, "Normal windows build" );
     #endif
 
-    // Free memory allocated by CommandLineToArgvA
-    GlobalFree(argv);
-
     #ifdef GIT_VERSION
         LOG_NOTE(__FILE__, "uTox version %s \n", GIT_VERSION);
     #endif
@@ -835,7 +842,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
     screen_grab_init(hInstance);
 
     OleInitialize(NULL);
-
 
     uint16_t langid = GetUserDefaultUILanguage() & 0xFFFF;
 
@@ -940,5 +946,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
 
     utox_raze();
 
-    return false;
+    // TODO: This should be a non-zero value determined by a message's wParam.
+    return 0;
 }

--- a/src/windows/notify.c
+++ b/src/windows/notify.c
@@ -4,9 +4,7 @@
 #include "window.h"
 
 #include "../debug.h"
-
 #include "../ui.h"
-// #include "../ui/layout_notify.h"
 
 #include <windowsx.h>
 

--- a/src/windows/os_video.c
+++ b/src/windows/os_video.c
@@ -3,6 +3,7 @@
 #include "main.h"
 
 #include "../debug.h"
+#include "../macros.h"
 #include "../main_native.h"
 
 #include "../av/video.h"
@@ -87,21 +88,20 @@ void video_end(uint32_t id) {
 volatile bool newframe = 0;
 uint8_t *     frame_data;
 
-HRESULT STDMETHODCALLTYPE test_SampleCB(ISampleGrabberCB *lpMyObj, double SampleTime, IMediaSample *pSample) {
+HRESULT STDMETHODCALLTYPE test_SampleCB(ISampleGrabberCB *UNUSED(lpMyObj), double UNUSED(SampleTime), IMediaSample *pSample) {
     // you can call functions like:
     // REFERENCE_TIME   tStart, tStop;
     void *sampleBuffer;
-    int   length;
 
     pSample->lpVtbl->GetPointer(pSample, (BYTE **)&sampleBuffer);
-    length = pSample->lpVtbl->GetActualDataLength(pSample);
+    uint16_t length = pSample->lpVtbl->GetActualDataLength(pSample);
 
     /*pSample->GetTime(&tStart, &tStop);
     */
     if (length == video_width * video_height * 3) {
         uint8_t *p = frame_data + video_width * video_height * 3;
-        int      y;
-        for (y = 0; y != video_height; y++) {
+
+        for (int y = 0; y != video_height; y++) {
             p -= video_width * 3;
             memcpy(p, sampleBuffer, video_width * 3);
             sampleBuffer += video_width * 3;
@@ -114,10 +114,12 @@ HRESULT STDMETHODCALLTYPE test_SampleCB(ISampleGrabberCB *lpMyObj, double Sample
     return S_OK;
 }
 
-STDMETHODIMP test_QueryInterface(ISampleGrabberCB *lpMyObj, REFIID riid, LPVOID FAR *lppvObj) {
+STDMETHODIMP test_QueryInterface(ISampleGrabberCB *UNUSED(lpMyObj), REFIID UNUSED(riid),
+                                 LPVOID FAR *UNUSED(lppvObj))
+{
     return 0;
 }
-STDMETHODIMP_(ULONG) test_AddRef(ISampleGrabberCB *lpMyObj) {
+STDMETHODIMP_(ULONG) test_AddRef(ISampleGrabberCB *UNUSED(lpMyObj)) {
     return 1;
 }
 
@@ -237,7 +239,7 @@ HRESULT ConnectFilters(IGraphBuilder *_pGraph, IBaseFilter *pSrc, IBaseFilter *p
 
 uint16_t native_video_detect(void) {
     // Indicate that we support desktop capturing.
-    utox_video_append_device((void *)1, 1, STR_VIDEO_IN_DESKTOP, 0);
+    utox_video_append_device((void *)1, 1, (void *)STR_VIDEO_IN_DESKTOP, 0);
 
     max_video_width  = GetSystemMetrics(SM_CXVIRTUALSCREEN);
     max_video_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);

--- a/src/windows/os_video.c
+++ b/src/windows/os_video.c
@@ -43,7 +43,7 @@ void *  dibits;
 
 static uint16_t video_x, video_y;
 
-void video_begin(uint32_t id, char *name, uint16_t name_length, uint16_t width, uint16_t height) {
+void video_begin(uint32_t id, char *UNUSED(name), uint16_t UNUSED(name_length), uint16_t width, uint16_t height) {
     if (video_hwnd[id]) {
         return;
     }

--- a/src/windows/screen_grab.c
+++ b/src/windows/screen_grab.c
@@ -67,12 +67,12 @@ static void sendbitmap(HDC mem, HBITMAP hbm, int width, int height) {
     }
 
     int size = 0;
-    UTOX_IMAGE *out = stbi_write_png_to_mem(bits, 0, width, height, 3, &size);
+    UTOX_IMAGE out = stbi_write_png_to_mem(bits, 0, width, height, 3, &size);
 
     free(bits);
 
     NATIVE_IMAGE *image = create_utox_image(hbm, 0, width, height);
-    friend_sendimage(flist_get_selected()->data, image, width, height, (UTOX_IMAGE)out, size);
+    friend_sendimage(flist_get_selected()->data, image, width, height, out, size);
 }
 
 static LRESULT CALLBACK screen_grab_sys(HWND window, UINT msg, WPARAM wParam, LPARAM lParam) {

--- a/src/windows/window.c
+++ b/src/windows/window.c
@@ -6,6 +6,7 @@
 
 #include "../branding.h"
 #include "../debug.h"
+#include "../macros.h"
 
 #include <windows.h>
 
@@ -31,7 +32,7 @@ void native_window_init(HINSTANCE instance) {
     RegisterClassW(&main_window_class);
 }
 
-void native_window_raze(UTOX_WINDOW *window) {
+void native_window_raze(UTOX_WINDOW *UNUSED(window)) {
     return;
 }
 
@@ -47,9 +48,11 @@ static bool update_DC_BM(UTOX_WINDOW *win, int w, int h) {
     return true;
 }
 
+#if 0
 static HWND window_create() {
     return NULL;
 }
+#endif
 
 
 UTOX_WINDOW *native_window_create_main(int x, int y, int w, int h) {
@@ -72,7 +75,8 @@ UTOX_WINDOW *native_window_create_main(int x, int y, int w, int h) {
 }
 
 HWND native_window_create_video(int x, int y, int w, int h) {
-    return CreateWindowExW(0, L"uTox Video", L"TEMP TITLE CHANGE ME", WS_OVERLAPPEDWINDOW, x, y, w, h, NULL, NULL, curr_instance, NULL);
+    return CreateWindowExW(0, L"uTox Video", L"TEMP TITLE CHANGE ME", WS_OVERLAPPEDWINDOW,
+                           x, y, w, h, NULL, NULL, curr_instance, NULL);
 }
 
 UTOX_WINDOW *popup = NULL;
@@ -139,6 +143,6 @@ void native_window_create_screen_select() {
     return;
 }
 
-void native_window_tween(UTOX_WINDOW *win) {
+void native_window_tween(UTOX_WINDOW *UNUSED(win)) {
     return;
 }


### PR DESCRIPTION
The problem with exporting chatlogs was that Windows uTox was using the `friend_number` instead of the `id_str`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/739)
<!-- Reviewable:end -->
