### PR TITLE
Always exit on LOG_FATAL_ERR, and convert exiting LOG_ERRs

### DIFF
--- a/src/av/audio.c
+++ b/src/av/audio.c
@@ -833,7 +833,7 @@ void utox_audio_thread(void *args) {
     audio_thread_msg       = 0;
     utox_audio_thread_init = 0;
     free(preview_buffer);
-    LOG_TRACE("uTox Audio", "Clean thread exit!" );
+    LOG_TRACE("uTox Audio", "Clean thread exit!");
 }
 
 // COMMENTED OUT FOR NEW GC

--- a/src/av/utox_av.c
+++ b/src/av/utox_av.c
@@ -247,7 +247,7 @@ void utox_av_ctrl_thread(void *args) {
     toxav_thread_msg  = 0;
     utox_av_ctrl_init = 0;
 
-    LOG_NOTE("UTOXAV", "Clean thread exit!" );
+    LOG_NOTE("UTOXAV", "Clean thread exit!");
     return;
 }
 

--- a/src/av/video.c
+++ b/src/av/video.c
@@ -320,7 +320,7 @@ void utox_video_thread(void *args) {
 
     video_thread_msg       = 0;
     utox_video_thread_init = 0;
-    LOG_TRACE("uToxVideo", "Clean thread exit!" );
+    LOG_TRACE("uToxVideo", "Clean thread exit!");
 }
 
 void yuv420tobgr(uint16_t width, uint16_t height, const uint8_t *y, const uint8_t *u, const uint8_t *v,

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,11 +1,15 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-enum exit_codes {
-    EXIT_NORMAL,
-    EXIT_UNKNOWN,
-    EXIT_MALLOC,
-};
+#include "stdlib.h"
+
+#ifndef EXIT_SUCCESS // should be defined in stdlib.h
+#define EXIT_SUCCESS 0 /* Successful exit status. */
+#endif
+#ifndef EXIT_FAILURE // should be defined in stdlib.h
+#define EXIT_FAILURE 1 /* Generic failing exit status. */
+#endif
+#define EXIT_MALLOC  2 /* Malloc failure exit status. */
 
 /* uTox debug levels */
 typedef enum {

--- a/src/devices.c
+++ b/src/devices.c
@@ -31,16 +31,14 @@ static bool realloc_devices_list(uint16_t new_size) {
 
 void utox_devices_init(void) {
     if (devices) {
-        LOG_ERR("Devices", "Unable to init base devices, *devices exists");
-        exit(1);
+        LOG_FATAL_ERR(EXIT_FAILURE, "Devices", "Unable to init base devices, *devices exists");
     }
 
     devices               = calloc(self.device_list_count, sizeof(UTOX_DEVICE));
     self.device_list_size = self.device_list_count;
 
     if (devices == NULL) {
-        LOG_ERR("Devices", "Unable to init base devices, *devices is null");
-        exit(2);
+        LOG_FATAL_ERR(EXIT_MALLOC, "Devices", "Unable to init base devices, *devices is null");
     }
 };
 
@@ -118,8 +116,7 @@ void devices_update_ui(void) {
         BUTTON *dele = calloc(1, sizeof(BUTTON));
 
         if (!edit) {
-            LOG_ERR(__FILE__, "Can't malloc for an extra device");
-            exit(7);
+            LOG_FATAL_ERR(EXIT_MALLOC, __FILE__, "Can't malloc for an extra device");
         }
 
         PANEL p_edit =

--- a/src/groups.c
+++ b/src/groups.c
@@ -121,8 +121,7 @@ void group_peer_add(GROUPCHAT *g, uint32_t peer_id, bool UNUSED(our_peer_number)
     // Allocate space for the struct and the dynamic array holding the peer's name.
     peer = calloc(1, sizeof(GROUP_PEER) + strlen(default_peer_name) + 1);
     if (!peer) {
-        LOG_ERR("Groupchat", "Unable to allocate space for group peer.");
-        exit(42); // TODO: Header file for exit codes. This is just silly.
+        LOG_FATAL_ERR(EXIT_MALLOC, "Groupchat", "Unable to allocate space for group peer.");
     }
     strcpy2(peer->name, default_peer_name);
     peer->name_length = 0;
@@ -181,8 +180,7 @@ void group_peer_name_change(GROUPCHAT *g, uint32_t peer_id, const uint8_t *name,
             peer = new_peer;
         } else {
             free(peer);
-            LOG_FATAL_ERR(40, "Groupchat", "Couldn't realloc for group peer name!");
-            exit(40);
+            LOG_FATAL_ERR(EXIT_MALLOC, "Groupchat", "couldn't realloc for group peer name!");
         }
 
         peer->name_length = utf8_validate(name, length);
@@ -198,8 +196,7 @@ void group_peer_name_change(GROUPCHAT *g, uint32_t peer_id, const uint8_t *name,
         if (new_peer) {
             peer = new_peer;
         } else {
-            LOG_FATAL_ERR(43, "Groupchat", "Unable to realloc for group peer who just joined.");
-            exit(43);
+            LOG_FATAL_ERR(EXIT_MALLOC, "Groupchat", "Unable to realloc for group peer who just joined.");
         }
 
         peer->name_length = utf8_validate(name, length);
@@ -209,8 +206,7 @@ void group_peer_name_change(GROUPCHAT *g, uint32_t peer_id, const uint8_t *name,
         group_add_message(g, peer_id, (const uint8_t *)"<- has joined the chat!", 23, MSG_TYPE_NOTICE);
         return;
     } else {
-        LOG_ERR("Groupchat", "We can't set a name for a null peer! %u" , peer_id);
-        exit(41);
+        LOG_FATAL_ERR(EXIT_FAILURE, "Groupchat", "We can't set a name for a null peer! %u" , peer_id);
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -229,8 +229,7 @@ void parse_args(int argc, char *argv[],
                 if (!strcmp(optarg, "start-on-boot")) {
                     *should_launch_at_startup = -1;
                 } else {
-                    LOG_ERR("", "Please specify a correct unset option (please check user manual for list of correct "
-                                "values).\n");
+                    LOG_NORM("Please specify a correct unset option (please check user manual for list of correct values).\n");
                     exit(EXIT_FAILURE);
                 }
                 break;

--- a/src/messages.c
+++ b/src/messages.c
@@ -130,8 +130,7 @@ static uint32_t message_add(MESSAGES *m, MSG_HEADER *msg) {
             }
 
             if (!m->data) {
-                LOG_ERR("Messages", "\n\n\nFATAL ERROR TRYING TO REALLOC FOR MESSAGES.\nTHIS IS A BUG, PLEASE REPORT!\n\n\n");
-                exit(30);
+                LOG_FATAL_ERR(EXIT_MALLOC, "Messages", "\n\n\nFATAL ERROR TRYING TO REALLOC FOR MESSAGES.\nTHIS IS A BUG, PLEASE REPORT!\n\n\n");
             }
         }
         m->data[m->number++] = msg;
@@ -419,7 +418,7 @@ bool message_log_to_disk(MESSAGES *m, MSG_HEADER *msg) {
 
             uint8_t *data = calloc(1, length);
             if (!data) {
-                LOG_FATAL_ERR(20, "Messages", "Can't calloc for chat logging data. size:%lu", length);
+                LOG_FATAL_ERR(EXIT_MALLOC, "Messages", "Can't calloc for chat logging data. size:%lu", length);
             }
             memcpy(data, &header, sizeof(header));
             memcpy(data + sizeof(header), author, author_length);
@@ -1485,7 +1484,7 @@ bool messages_mright(PANEL *panel) {
         }
     }
 
-    LOG_FATAL_ERR(1, "Messages", "Congratulations, you've reached dead code. Please report this.");
+    LOG_FATAL_ERR(EXIT_FAILURE, "Messages", "Congratulations, you've reached dead code. Please report this.");
 }
 
 bool messages_mwheel(PANEL *UNUSED(panel), int UNUSED(height), double UNUSED(d), bool UNUSED(smooth)) {
@@ -1716,8 +1715,7 @@ void messages_init(MESSAGES *m, uint32_t friend_number) {
 
     m->data = calloc(20, sizeof(void *));
     if (!m->data) {
-        LOG_ERR("Messages", "\n\n\nFATAL ERROR TRYING TO CALLOC FOR MESSAGES.\nTHIS IS A BUG, PLEASE REPORT!\n\n\n");
-        exit(30);
+        LOG_FATAL_ERR(EXIT_MALLOC, "Messages", "\n\n\nFATAL ERROR TRYING TO CALLOC FOR MESSAGES.\nTHIS IS A BUG, PLEASE REPORT!\n\n\n");
     }
 
     m->extra = 20;

--- a/src/tox.c
+++ b/src/tox.c
@@ -84,8 +84,7 @@ static int utox_encrypt_data(void *clear_text, size_t clear_length, uint8_t *cyp
     tox_pass_encrypt((uint8_t *)clear_text, clear_length, (uint8_t *)passphrase, passphrase_length, cypher_data, &err);
 
     if (err) {
-        LOG_FATAL_ERR(10, __FILE__, "Fatal Error; unable to encrypt data!");
-        exit(10);
+        LOG_FATAL_ERR(EXIT_FAILURE, __FILE__, "Fatal Error; unable to encrypt data!\n");
     }
 
     return err;
@@ -565,13 +564,13 @@ void toxcore_thread(void *UNUSED(args)) {
         }
 
         // Stop av threads, and toxcore.
-        LOG_TRACE("Toxcore", "av_thread exit, tox thread ending" );
+        LOG_TRACE("Toxcore", "av_thread exit, tox thread ending");
         toxav_kill(av);
         tox_kill(tox);
     }
 
     tox_thread_init = UTOX_TOX_THREAD_INIT_NONE;
-    LOG_TRACE("Toxcore", "Tox thread:\tClean exit!" );
+    LOG_TRACE("Toxcore", "Tox thread:\tClean exit!");
 }
 
 /** General recommendations for working with threads in uTox

--- a/src/tox_callbacks.c
+++ b/src/tox_callbacks.c
@@ -242,7 +242,7 @@ static void callback_group_namelist_change(Tox *tox, uint32_t gid, uint32_t pid,
             g->peer = calloc(number_peers, sizeof(void *));
 
             if (!g->peer) {
-                LOG_FATAL_ERR(44, "Tox Callbacks", "Group:\tToxcore is very broken, but we couldn't alloc here.");
+                LOG_FATAL_ERR(EXIT_MALLOC, "Tox Callbacks", "Group:\tToxcore is very broken, but we couldn't alloc here.");
             }
 
             /* I'm about to break some uTox style here, because I'm expecting
@@ -253,8 +253,7 @@ static void callback_group_namelist_change(Tox *tox, uint32_t gid, uint32_t pid,
                 tox_conference_peer_get_name(tox, gid, i, tmp, NULL);
                 GROUP_PEER *peer = calloc(1, len * sizeof(void *) + sizeof(*peer));
                 if (!peer) {
-                    debug("Group:\tToxcore is very broken, but we couldn't calloc here.");
-                    exit(45);
+                    LOG_FATAL_ERR(EXIT_MALLOC, "Group", "Toxcore is very broken, but we couldn't calloc here.");
                 }
                 /* name and id number (it's worthless, but it's needed */
                 memcpy(peer->name, tmp, len);

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -936,7 +936,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
     };
     config_save(&d);
 
-    LOG_INFO("uTox", "Clean exit." );
+    LOG_INFO("uTox", "Clean exit.");
 
     utox_raze();
 

--- a/src/xlib/dbus.c
+++ b/src/xlib/dbus.c
@@ -61,7 +61,7 @@ void dbus_notify(char *title, char *content, uint8_t *cid) {
     conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
 
     if (dbus_error_is_set(&err)) {
-        fprintf(stderr, "Connection Error (%s)\n", err.message);
+        LOG_ERR(__FILE__, "Connection Error (%s)\n", err.message);
         dbus_error_free(&err);
     }
 
@@ -92,8 +92,7 @@ void dbus_notify(char *title, char *content, uint8_t *cid) {
     dbus_error_init(&err);
 
     if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-        fprintf(stderr, "Sending failed!\n");
-        exit(1);
+        LOG_FATAL_ERR(EXIT_FAILURE, __FILE__, "Sending failed!");
     }
 
     if (!dbus_pending_call_set_notify(pending, &notify_callback, NULL, NULL)) {

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -676,8 +676,7 @@ int main(int argc, char *argv[]) {
     theme_load(settings.theme);
 
     if (!XInitThreads()) {
-        LOG_FATAL_ERR(2, "XLIB MAIN", "XInitThreads failed.");
-        return 2;
+        LOG_FATAL_ERR(EXIT_FAILURE, "XLIB MAIN", "XInitThreads failed.");
     }
     if (!native_window_init()) {
         return 2;
@@ -880,7 +879,7 @@ int main(int argc, char *argv[]) {
         yieldcpu(1);
     }
 
-    LOG_ERR("XLIB", "XLIB main:\tClean exit");
+    LOG_INFO("XLIB", "XLIB main:\tClean exit");
 
     utox_raze();
 

--- a/src/xlib/v4l.c
+++ b/src/xlib/v4l.c
@@ -164,8 +164,7 @@ bool v4l_init(char *dev_name) {
     }
 
     if (req.count < 2) {
-        fprintf(stderr, "Insufficient buffer memory on %s\n", dev_name);
-        exit(EXIT_FAILURE);
+        LOG_FATAL_ERR(EXIT_MALLOC, __FILE__, "Insufficient buffer memory on %s", dev_name);
     }
 
     buffers = calloc(req.count, sizeof(*buffers));

--- a/src/xlib/window.c
+++ b/src/xlib/window.c
@@ -126,8 +126,7 @@ UTOX_WINDOW *native_window_create_main(int x, int y, int w, int h, char **argv, 
 
     if (!native_window_create(&main_window, title, CWBackPixmap | CWBorderPixel | CWEventMask,
                       x, y, w, h, MAIN_WIDTH, MAIN_HEIGHT, &panel_root, false)) {
-        LOG_FATAL_ERR(2, __FILE__, "Unable to create main window.");
-        return NULL;
+        LOG_FATAL_ERR(EXIT_FAILURE, __FILE__, "Unable to create main window.");
     }
 
     Atom a_pid  = XInternAtom(display, "_NET_WM_PID", 0);


### PR DESCRIPTION
- made LOG_FATAL_ERR always print the error and always exit.
- cleanup exit codes and use LOG_FATAL_ERR in case LOG_ERR was used with exit()
- some other minor log message cleanups

fixes #748

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/751)
<!-- Reviewable:end -->
