### PR TITLE
Stop uTox from segfaulting when a peer is missing from gc.

### DIFF
--- a/src/groups.c
+++ b/src/groups.c
@@ -31,7 +31,7 @@ GROUPCHAT *get_group(uint32_t group_number) {
 void group_init(GROUPCHAT *g, uint32_t group_number, bool av_group) {
     pthread_mutex_lock(&messages_lock); /* make sure that messages has posted before we continue */
     if (!g->peer) {
-        g->peer = calloc(MAX_GROUP_PEERS, sizeof(GROUP_PEER *));
+        g->peer = calloc(UTOX_MAX_GROUP_PEERS, sizeof(GROUP_PEER *));
     }
 
     g->name_length = snprintf((char *)g->name, sizeof(g->name), "Groupchat #%u", group_number);
@@ -53,7 +53,7 @@ void group_init(GROUPCHAT *g, uint32_t group_number, bool av_group) {
     g->msg.panel.y              = MAIN_TOP;
     g->msg.panel.height         = CHAT_BOX_TOP;
     g->msg.panel.width          = -SCROLL_WIDTH;
-    g->msg.is_groupchat         = 1;
+    g->msg.is_groupchat         = true;
 
     g->number   = group_number;
     g->notify   = settings.group_notifications;
@@ -66,14 +66,18 @@ void group_init(GROUPCHAT *g, uint32_t group_number, bool av_group) {
 
 uint32_t group_add_message(GROUPCHAT *g, uint32_t peer_id, const uint8_t *message, size_t length, uint8_t m_type) {
     pthread_mutex_lock(&messages_lock); /* make sure that messages has posted before we continue */
+
+    if (peer_id >= UTOX_MAX_GROUP_PEERS) {
+        LOG_ERR("Groupchats", "Unable to add message from peer %u - peer id too large.", peer_id);
+        return UINT32_MAX;
+    }
+
     const GROUP_PEER *peer = g->peer[peer_id];
     if (!peer) {
         LOG_ERR("Groupchats", "Unable to get peer %u for adding message.", peer_id);
         pthread_mutex_unlock(&messages_lock);
         return UINT32_MAX;
     }
-
-    MESSAGES *m = &g->msg;
 
     MSG_HEADER *msg = calloc(1, sizeof(MSG_HEADER));
     if (!msg) {
@@ -94,7 +98,6 @@ uint32_t group_add_message(GROUPCHAT *g, uint32_t peer_id, const uint8_t *messag
     msg->via.grp.author = calloc(1, peer->name_length);
     if (!msg->via.grp.author) {
         LOG_ERR("Groupchat", "Unable to allocate space for author nickname.");
-
         free(msg);
         return UINT32_MAX;
     }
@@ -103,7 +106,6 @@ uint32_t group_add_message(GROUPCHAT *g, uint32_t peer_id, const uint8_t *messag
     msg->via.grp.msg = calloc(1, length);
     if (!msg->via.grp.msg) {
         LOG_ERR("Groupchat", "Unable to allocate space for message.");
-
         free(msg->via.grp.author);
         free(msg);
         return UINT32_MAX;
@@ -112,22 +114,21 @@ uint32_t group_add_message(GROUPCHAT *g, uint32_t peer_id, const uint8_t *messag
 
     pthread_mutex_unlock(&messages_lock);
 
+    MESSAGES *m = &g->msg;
     return message_add_group(m, msg);
 }
 
 void group_peer_add(GROUPCHAT *g, uint32_t peer_id, bool UNUSED(our_peer_number), uint32_t name_color) {
     pthread_mutex_lock(&messages_lock); /* make sure that messages has posted before we continue */
     if (!g->peer) {
-        g->peer = calloc(MAX_GROUP_PEERS, sizeof(void));
+        g->peer = calloc(UTOX_MAX_GROUP_PEERS, sizeof(GROUP_PEER *));
         LOG_NOTE("Groupchat", "Needed to calloc peers for this group chat. (%u)" , peer_id);
     }
 
-    GROUP_PEER *peer = g->peer[peer_id];
-
-    char *default_peer_name = "<unknown>";
+    const char *default_peer_name = "<unknown>";
 
     // Allocate space for the struct and the dynamic array holding the peer's name.
-    peer = calloc(1, sizeof(GROUP_PEER) + strlen(default_peer_name) + 1);
+    GROUP_PEER *peer = calloc(1, sizeof(GROUP_PEER) + strlen(default_peer_name) + 1);
     if (!peer) {
         LOG_FATAL_ERR(EXIT_MALLOC, "Groupchat", "Unable to allocate space for group peer.");
     }

--- a/src/groups.h
+++ b/src/groups.h
@@ -6,7 +6,7 @@
 typedef unsigned int ALuint;
 typedef struct edit_change EDIT_CHANGE;
 
-#define MAX_GROUP_PEERS 256
+#define UTOX_MAX_GROUP_PEERS 256
 #define UTOX_MAX_NUM_GROUPS 64
 
 /*  UTOX_SAVE limits 8 as the max */
@@ -44,9 +44,9 @@ typedef struct groupchat {
     char *typed;
 
     /* Audio sources */
-    unsigned int source[MAX_GROUP_PEERS];
+    unsigned int source[UTOX_MAX_GROUP_PEERS];
     volatile uint64_t
-        last_recv_audio[MAX_GROUP_PEERS]; /* TODO: thread safety (This should work fine but it isn't very clean.) */
+        last_recv_audio[UTOX_MAX_GROUP_PEERS]; /* TODO: thread safety (This should work fine but it isn't very clean.) */
 
     MESSAGES      msg;
     EDIT_CHANGE **edit_history;


### PR DESCRIPTION
Also fixes incorrect `calloc` size (we want a list of pointers to `GROUP_PEER`) and makes it portable. `sizeof(void)` is a gcc extension and invalid standard C. It should generate a compile-time error.

This doesn't fix the root cause of the groupchat crash which is that if a uTox user creates a groupchat, his own peer number is never added to the groupchat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/759)
<!-- Reviewable:end -->
