### PR TITLE
[WIP] Prevent in-source builds and enforce out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Prevent in-source-tree build and enforce out-of-source builds
+include(cmake/outofsource-build.cmake)
+
 cmake_minimum_required(VERSION 3.2)
 project(uTox LANGUAGES C)
 

--- a/cmake/outofsource-build.cmake
+++ b/cmake/outofsource-build.cmake
@@ -7,6 +7,8 @@
 # $ cd build
 # $ cmake ../
 #
+# But I recommend something like shown in error message below.
+
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message(FATAL_ERROR "CMake has been ran to create an in-source build. Please create a 'build' path like following and run cmake in there:
 

--- a/cmake/outofsource-build.cmake
+++ b/cmake/outofsource-build.cmake
@@ -1,0 +1,20 @@
+# This file prevents an in-source-tree build which would mix cloned files and
+# build files.
+#
+# Now you have to do at least:
+#
+# $ mkdir build
+# $ cd build
+# $ cmake ../
+#
+if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+	message(FATAL_ERROR "CMake has been ran to create an in-source build. Please create a 'build' path like following and run cmake in there:
+
+$ mkdir build/
+$ cd ./build/
+$ cmake ../
+
+This allows you to have multiple builds (e.g. debug and release) from same source code tree and no build files are being mixed with source files.
+And please cleanup CMakeFiles/ and CMakeCache.txt, this cannot be done from a cmake file:
+https://cmake.org/pipermail/cmake/2014-January/056789.html")
+endif ()

--- a/cmake/outofsource-build.cmake
+++ b/cmake/outofsource-build.cmake
@@ -10,9 +10,9 @@
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message(FATAL_ERROR "CMake has been ran to create an in-source build. Please create a 'build' path like following and run cmake in there:
 
-$ mkdir build/
-$ cd ./build/
-$ cmake ../
+$ mkdir -p build/debug
+$ cd build/debug
+$ cmake ../.. -DCMAKE_BUILD_TYPE=Debug
 
 This allows you to have multiple builds (e.g. debug and release) from same source code tree and no build files are being mixed with source files.
 And please cleanup CMakeFiles/ and CMakeCache.txt, this cannot be done from a cmake file:


### PR DESCRIPTION
This PR changes the following this:
- cmake module added for detection of toxcore
- CMakeLists.txt is now "scanning" cmake/ directory for modules (not recursive)
- moved Windows-related cmake files to sub-folder (to have them away for above mentioned loader)
- removed + ignored auto-generated files as this leads to dirty checkout directory
- I don't know if `GNUInstallDirs` is really changing somthing, but FlightGear uses it?
- Toxcore now must be found (indeed needed)
- **DO NOT MERGE! WIP!**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/791)
<!-- Reviewable:end -->
