### PR TITLE
Fix markdown formatting

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -5,7 +5,6 @@ probably help you out.
 
 If you're looking for it to "just work" you're going to want [these instructions](INSTALL.md).
 
-<a name="unix" />
 ## Unix Like
 
 ### Linux
@@ -41,7 +40,6 @@ For the build to pass you need to install the following from sources: [filteraud
 
 For base emoji ids support you need: [base_emoji](https://github.com/irungentoo/base_emoji)
 
-<a name="ubuntu15_10">
 ## Ubuntu
 ### Tested on Ubuntu 15.10
 ```bash
@@ -85,7 +83,6 @@ Have fun!
 
 If you're looking for a good IDE, Netbeans is very easy to set up for uTox. In fact, you can just create a new project from the existing sources and everything should work fine.
 
-<a name="OpenBSD" />
 ## OpenBSD
 
 uTox will compile on OpenBSD although not everything works. To compile run:
@@ -100,7 +97,6 @@ make
 sudo make install
 ```
 
-<a name="win" />
 ## Windows
 
 ### Compiling for Windows
@@ -140,12 +136,10 @@ cmake -DCMAKE_TOOLCHAIN_FILE="../cmake/toolchain-win64.cmake" -DTOXCORE_STATIC=O
 make
 ```
 
-<a name="osx" />
 ## OSX
 
 See [COCOA.md](COCOA.md).
 
-<a name="and" />
 ## Android
 
 Requires Android SDK+NDK

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,12 +4,11 @@ The following steps install μTox on your computron/toaster/carrier pigeon. This
 
 For any and all of the following, you'll need to have [toxcore](https://github.com/TokTok/c-toxcore) installed first.
 
-- [Unix-like](#unix)
-- [OS X](#osx)
+- [Unix-like](#unix-like)
+- [OS X](#os-x)
 - [Windows](#windows)
 - [Android](#android)
 
-<a name="unix" />
 ## Unix-like
 
 Dependencies:
@@ -65,16 +64,14 @@ If you use Slackware you can download the slack build from here: https://slackbu
 
 ## OpenBSD
 
-Right now no one is providing binaries. You will have to compile uTox. See [instructions](BUILD.md#OpenBSD).
+Right now no one is providing binaries. You will have to compile uTox. See [instructions](BUILD.md#openbsd).
 
-<a name="osx" />
 ## OS X
 
 No one is currently providing binaries for OSX yet... Sorry Apple people... you should ask @stal888 to do something about that!
 
-[I guess I'll try to build it](BUILD.md#OSX).
+[I guess I'll try to build it](BUILD.md#osx).
 
-<a name="windows" />
 ## Windows
 
 Installing on windows isn't really a thing yet... you can download the nighties. They should just work.
@@ -83,7 +80,6 @@ Installing on windows isn't really a thing yet... you can download the nighties.
   - [64-bit](https://build.tox.chat/job/uTox_build_windows_x86-64_release/lastSuccessfulBuild/artifact/utox_windows_x86-64.zip)
   - Updater (delayed, ask grayhatter for it, and it'll happen)
 
-<a name="android" />
 ## Android
 
 Install uTox from the Google Play Store or download the APK: [uTox.apk](https://build.tox.chat/job/uTox_build_android_armhf_release/lastSuccessfulBuild/artifact/uTox.apk)


### PR DESCRIPTION
Fixed broken formatting of some markdown files which resulted from [GitHub changing spec of their Markdown parser](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown), which removed support for custom anchors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/817)
<!-- Reviewable:end -->
