### PR TITLE
Improve cmake ASAN behaviour.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,12 @@ endif()
 # https://gcc.gnu.org/gcc-4.8/changes.html
 # https://github.com/google/sanitizers/wiki/AddressSanitizer
 if (ENABLE_ASAN)
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer")
+    if (UTOX_STATIC)
+        message(SEND_ERROR "ASAN is incompatible with static compilation.")
+    endif()
+
+    add_cflag("-fsanitize=address")
+    add_cflag("-fno-omit-frame-pointer")
 endif()
 
 if(ENABLE_WERROR)

--- a/cmake/win.cmake
+++ b/cmake/win.cmake
@@ -8,6 +8,12 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAL_LIBTYPE_STATIC")
 set(UTOX_STATIC ON)
 set(TOXCORE_STATIC ON)
 
+# ASAN is incompatible with static compilation.
+if (ENABLE_ASAN)
+    message(WARNING "ASAN is incompatible with static compilation and will be disabled.")
+    set(ENABLE_ASAN OFF)
+endif()
+
 # Required for line numbers in gdb on Windows.
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g3" CACHE STRING "" FORCE)


### PR DESCRIPTION
Now ASAN will be enabled in all build types if you specify `-DENABLE_ASAN=1`
Windows will warn about ASAN+static compilation and allow compilation with the default settings on all build types. (Previously, it would fail for debug builds since that's the only place where ASAN was enabled.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/828)
<!-- Reviewable:end -->
