### PR TITLE
Remove #include <malloc.h> from tests

### DIFF
--- a/tests/test.h
+++ b/tests/test.h
@@ -2,7 +2,6 @@
 #include "../src/settings.h"
 
 #include <assert.h>
-#include <malloc.h>
 #include <memory.h>
 #include <stdarg.h>
 #include <stdlib.h>


### PR DESCRIPTION
`#include <malloc.h>` breaks OS X builds, and is redundant with `#include <stdlib.h>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/858)
<!-- Reviewable:end -->
