### PR TITLE
Fix null dereference in edit.c

### DIFF
--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -414,8 +414,10 @@ enum {
 
 void edit_char(uint32_t ch, bool control, uint8_t flags) {
     if (!active_edit) {
+        LOG_ERR("UI Edit", "Stopped you from crashing becase no edit was active or something.");
         return;
     }
+
     EDIT *edit = active_edit; // TODO this is bad
 
     // shift:   flags & 1

--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -413,9 +413,13 @@ enum {
 };
 
 void edit_char(uint32_t ch, bool control, uint8_t flags) {
-    /* shift: flags & 1
-     * control: flags & 4 */
+    if (!active_edit) {
+        return;
+    }
     EDIT *edit = active_edit; // TODO this is bad
+
+    // shift:   flags & 1
+    // control: flags & 4
 
     if (control || (ch <= 0x1F && (!edit->multiline || ch != '\n')) || (ch >= 0x7f && ch <= 0x9F)) {
         bool modified = false;


### PR DESCRIPTION
To reproduce the crash this fixes:
```
tssx: click between settings tab(no button on off, just between tabs), then right click in friend search tab and press 2 mouse buttons on cut selection
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/920)
<!-- Reviewable:end -->
