### PR TITLE
fix potential crash on macOS when video input == nil

### DIFF
--- a/src/cocoa/video.m
+++ b/src/cocoa/video.m
@@ -70,12 +70,17 @@
             AVCaptureDevice *dev = [[ad getCaptureDeviceFromHandle:video_dev_handle] retain];
 
             if (!dev) {
+                LOG_TRACE("uTox Video", "Unable to find video device!");
                 return nil;
             }
 
             NSError *       error = NULL;
             AVCaptureInput *input = [[AVCaptureDeviceInput alloc] initWithDevice:dev error:&error];
             [_session beginConfiguration];
+            if (!input) {
+                LOG_TRACE("uTox Video", "Unable to open video device!");
+                return nil;
+            }
             [_session addInput:input];
             _session.sessionPreset = AVCaptureSessionPreset640x480;
             [_session commitConfiguration];


### PR DESCRIPTION
My webcam in my mac has problems sometimes :stuck_out_tongue_closed_eyes:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/930)
<!-- Reviewable:end -->
