### PR TITLE
Check resumeable file pointer with fstat.

### DIFF
--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -16,6 +16,7 @@
 #include "native/time.h"
 
 #include <string.h>
+#include <sys/stat.h>
 
 #define MAX_INCOMING_COUNT 32
 
@@ -188,17 +189,27 @@ static bool resumeable_name(FILE_TRANSFER *ft, char *name) {
 }
 
 static bool ft_update_resumable(FILE_TRANSFER *ft) {
-    if (ft->resume_file) {
-        fseeko(ft->resume_file, SEEK_SET, 0);
-        if (fwrite(ft, sizeof(FILE_TRANSFER), 1, ft->resume_file) == 1) {
-            fflush(ft->resume_file);
-            return true;
-        }
+    if (!ft->resume_file) {
+        LOG_ERR("FileTransfer", "Unable to save filetransfer info. Got NULL file pointer.");
+        return false;
     }
 
-    LOG_ERR("FileTransfer", "Unable to save file info... uTox can't resume file %.*s",
-                (int)ft->name_length, ft->name);
-    return false;
+    // This file pointer has a tendency of being both invalid and non-null so we use fstat to check it.
+    struct stat buffer;
+    if (fstat(fileno(ft->resume_file), &buffer) != 0) {
+        LOG_ERR("FileTransfer", "Unable to save file info. Invalid filepointer.");
+        return false;
+    }
+
+    fseeko(ft->resume_file, SEEK_SET, 0);
+    if (fwrite(ft, sizeof(FILE_TRANSFER), 1, ft->resume_file) != 1) {
+        LOG_ERR("FileTransfer", "Unable to save file info... uTox can't resume file %.*s",
+                ft->name_length, ft->name);
+        return false;
+    }
+
+    fflush(ft->resume_file);
+    return true;
 }
 
 /* Create the file transfer resume info file. */


### PR DESCRIPTION
This hopefully fixes a crash where uTox tries to fseek an invalid file pointer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/933)
<!-- Reviewable:end -->
