### PR TITLE
Disable asan on static Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,29 +12,6 @@ set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT
 
 set(PROJECT_COPYRIGHT "Copyleft 2017 uTox contributors. Some rights reserved.")
 
-
-###########
-# Options #
-###########
-
-if (APPLE) # disable ASAN for macOS due to "AddressSanitizer: odr-violation: global". see #957
-    set(ASAN_DEFAULT OFF)
-else()
-    set(ASAN_DEFAULT ON)
-endif()
-
-option(ENABLE_ASAN          "Enable Address Sanitizer on debug builds"                      ${ASAN_DEFAULT} )
-option(ENABLE_TESTS         "Whether to build test binaries (currently linux only)"         ON )
-option(ENABLE_WERROR        "Error on Warning, whether to put -Werror flag to the compiler" OFF)
-option(ENABLE_FILTERAUDIO   "Enable Filter Audio"                                           ON )
-option(ENABLE_AUTOUPDATE    "Enable Auto-updater"                                           OFF)
-
-option(UTOX_STATIC          "Link uTox statically"                                          OFF)
-option(TOXCORE_STATIC       "Build uTox with the static version of Toxcore"                 OFF)
-
-option(ENABLE_LTO           "Enable link time optimizations"                                ON )
-
-
 ########################
 # Set helper-variables #
 ########################
@@ -70,6 +47,27 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 else()
   set(ARCH_64 FALSE)
 endif()
+
+###########
+# Options #
+###########
+
+option(UTOX_STATIC          "Link uTox statically"                                          OFF)
+option(TOXCORE_STATIC       "Build uTox with the static version of Toxcore"                 OFF)
+
+if (APPLE OR (UTOX_STATIC AND WINDOWS)) # disable ASAN for macOS due to "AddressSanitizer: odr-violation: global". see #957
+    set(ASAN_DEFAULT OFF)
+else()
+    set(ASAN_DEFAULT ON)
+endif()
+
+option(ENABLE_ASAN          "Enable Address Sanitizer on debug builds"          ${ASAN_DEFAULT})
+option(ENABLE_TESTS         "Whether to build test binaries (currently linux only)"         ON )
+option(ENABLE_WERROR        "Error on Warning, whether to put -Werror flag to the compiler" OFF)
+option(ENABLE_FILTERAUDIO   "Enable Filter Audio"                                           ON )
+option(ENABLE_AUTOUPDATE    "Enable Auto-updater"                                           OFF)
+
+option(ENABLE_LTO           "Enable link time optimizations"                                ON )
 
 
 #################################

--- a/cmake/toolchain-win32.cmake
+++ b/cmake/toolchain-win32.cmake
@@ -37,5 +37,3 @@ set(WIN32 TRUE) # This is for cmake
 
 set(UNIX FALSE)
 set(CROSS_COMPILING TRUE)
-
-set(ENABLE_ASAN OFF CACHE STRING "" FORCE)

--- a/cmake/toolchain-win64.cmake
+++ b/cmake/toolchain-win64.cmake
@@ -37,5 +37,3 @@ set(WIN32 TRUE) # This is for cmake
 set(WIN64 TRUE) # This is for uTox lib dirs
 set(UNIX FALSE)
 set(CROSS_COMPILING TRUE)
-
-set(ENABLE_ASAN OFF CACHE STRING "" FORCE)

--- a/cmake/win.cmake
+++ b/cmake/win.cmake
@@ -8,12 +8,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAL_LIBTYPE_STATIC")
 set(UTOX_STATIC ON)
 set(TOXCORE_STATIC ON)
 
-# ASAN is incompatible with static compilation.
-if (ENABLE_ASAN)
-    message(WARNING "ASAN is incompatible with static compilation and will be disabled.")
-    set(ENABLE_ASAN OFF)
-endif()
-
 # Required for line numbers in gdb on Windows.
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g3" CACHE STRING "" FORCE)


### PR DESCRIPTION
By default disable ASAN on static builds. Sorry for the delay, I had a ton of windows updates on my VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/974)
<!-- Reviewable:end -->
