### PR TITLE
Fix AV IO dropdowns breaking after Tox-thread restart.

### DIFF
--- a/src/av/audio.c
+++ b/src/av/audio.c
@@ -770,6 +770,8 @@ void utox_audio_thread(void *args) {
 
                 case UTOXAUDIO_NEW_AV_INSTANCE: {
                     av = m->data;
+                    audio_in_init();
+                    audio_out_init();
                 }
             }
             audio_thread_msg = 0;

--- a/src/av/video.c
+++ b/src/av/video.c
@@ -221,11 +221,8 @@ void postmessage_video(uint8_t msg, uint32_t param1, uint32_t param2, void *data
     video_thread_msg = true;
 }
 
-void utox_video_thread(void *args) {
-    ToxAV *av = args;
-
-    pthread_mutex_init(&video_thread_lock, NULL);
-
+// Populates the video device dropdown.
+static void init_video_devices(void) {
     // Add always-present null video input device.
     utox_video_append_device(NULL, 1, (void *)STR_VIDEO_IN_NONE, 1);
 
@@ -239,6 +236,14 @@ void utox_video_thread(void *args) {
             close_video_device(video_device[video_device_current]);
         }
     }
+}
+
+void utox_video_thread(void *args) {
+    ToxAV *av = args;
+
+    pthread_mutex_init(&video_thread_lock, NULL);
+
+    init_video_devices();
 
     utox_video_thread_init = 1;
 
@@ -251,6 +256,7 @@ void utox_video_thread(void *args) {
             switch (video_msg.msg) {
                 case UTOXVIDEO_NEW_AV_INSTANCE: {
                     av = video_msg.data;
+                    init_video_devices();
                     break;
                 }
             }


### PR DESCRIPTION
Fixes #992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/994)
<!-- Reviewable:end -->
