### PR TITLE
Don't require Check.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,7 @@ endif()
 # packaging
 include(CPack)
 
+
 ###########
 # Testing #
 ###########
@@ -403,8 +404,13 @@ include(CPack)
 if(ENABLE_TESTS)
   if(UNIX)
     # Tests currently only run on Linux and macOS.
-    enable_testing()
-    add_subdirectory(tests)
+    find_package(Check)
+    if(CHECK_FOUND)
+        enable_testing()
+        add_subdirectory(tests)
+    else()
+        message(WARNING "Testing enabled, but couldn't find Check!")
+    endif()
   endif()
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,8 +3,6 @@ include(CTest)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
-find_package(Check REQUIRED)
-
 function(make_test name)
     add_executable(test_${name} test_${name}.c)
     set_target_properties(test_${name} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")


### PR DESCRIPTION
Since testing is enabled by default I've had a lot of complaints about compilation failing because of check. This stops compilation from failing and instead warns about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1012)
<!-- Reviewable:end -->
