### PR TITLE
Fix uTox not linking against all required Tox libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,25 +262,20 @@ if(ENABLE_AUTOUPDATE)
     add_cflag("-DENABLE_AUTOUPDATE=1")
 endif()
 
-if(TOXCORE_STATIC AND WIN32)
-    # The static windows libs need all of these... because REASONS!
-    find_package(libtox REQUIRED COMPONENTS
-        toxencryptsave
-        toxav
-        toxcore
-        toxgroup
-        toxmessenger
-        toxfriends
-        toxdht
-        toxnetcrypto
-        toxcrypto
-        toxnetwork
-    )
-else()
-    find_package(libtox REQUIRED COMPONENTS toxencryptsave toxav toxcore)
-endif()
+find_package(libtox REQUIRED COMPONENTS
+    toxencryptsave
+    toxav
+    toxcore
+    toxgroup
+    toxmessenger
+    toxfriends
+    toxdht
+    toxnetcrypto
+    toxcrypto
+    toxnetwork
+)
+
 include_directories(${LIBTOX_INCLUDE_DIRS})
-set(TOX_LIBS ${LIBTOX_LIBRARIES})
 
 find_package(libsodium REQUIRED)
 include_directories(${LIBSODIUM_INCLUDE_DIRS})
@@ -363,13 +358,18 @@ add_executable(utox ${GUI_TYPE}
 
     ${WINDOWS_ICON}
     ${APPLE_FILES}
-
-    )
+)
 
 target_link_libraries(utox
-        utoxAV        utoxNATIVE      utoxUI
-        ${TOX_LIBS}   ${LIBRARIES}
-        vpx           pthread         m )
+    utoxAV
+    utoxNATIVE
+    utoxUI
+    ${LIBTOX_LIBRARIES}
+    ${LIBRARIES}
+    vpx
+    pthread
+    m
+)
 
 set_property(TARGET utox PROPERTY C_STANDARD 11)
 


### PR DESCRIPTION
After we added the FindTox Cmake module, Jenkins fails to link against Toxcore unless you find all packages. 

For evidence/an example, see the sed magic I did in https://build.tox.chat/view/uTox/job/uTox_build_linux_x86-64_release/ to get it to link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1015)
<!-- Reviewable:end -->
