### PR TITLE
Support Tox URI

### DIFF
--- a/src/cocoa/main.m
+++ b/src/cocoa/main.m
@@ -3,6 +3,7 @@
 #include "../commands.h"
 #include "../debug.h"
 #include "../filesys.h"
+#include "../flist.h"
 #include "../main.h"
 #include "../settings.h"
 #include "../theme.h"
@@ -136,20 +137,6 @@ uint64_t get_time(void) {
     ts.tv_nsec = machtime.tv_nsec;
 
     return ((uint64_t)ts.tv_sec * (1000 * 1000 * 1000)) + (uint64_t)ts.tv_nsec;
-}
-
-void openurl(char *str) {
-    NSString *urls = [[NSString alloc] initWithCString:(char *)str encoding:NSUTF8StringEncoding];
-
-    NSURL *url = NULL;
-    if (!strncasecmp((const char *)str, "http://", 7) || !strncasecmp((const char *)str, "https://", 8)) {
-        url = [NSURL URLWithString:urls];
-    } else /* it's a path */ {
-        url = [NSURL fileURLWithPath:urls];
-    }
-
-    [[NSWorkspace sharedWorkspace] openURL:url];
-    [urls release];
 }
 
 void config_osdefaults(UTOX_SAVE *r) {
@@ -302,6 +289,25 @@ void exit_ptt(void) {
 void redraw(void) {
     uToxAppDelegate *ad = (uToxAppDelegate *)[NSApp delegate];
     [ad soilWindowContents];
+}
+
+void openurl(char *str) {
+    if (try_open_tox_uri(str)) {
+        redraw();
+        return;
+    }
+
+    NSString *urls = [[NSString alloc] initWithCString:(char *)str encoding:NSUTF8StringEncoding];
+
+    NSURL *url = NULL;
+    if (!strncasecmp((const char *)str, "http://", 7) || !strncasecmp((const char *)str, "https://", 8)) {
+        url = [NSURL URLWithString:urls];
+    } else /* it's a path */ {
+        url = [NSURL fileURLWithPath:urls];
+    }
+
+    [[NSWorkspace sharedWorkspace] openURL:url];
+    [urls release];
 }
 
 void launch_at_startup(bool should) {

--- a/src/flist.c
+++ b/src/flist.c
@@ -919,14 +919,11 @@ bool try_open_tox_uri(const char *str) {
 
     if (friend) {
         flist_selectchat(friend->number);
-    }
-    else {
-        if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
-            edit_setstr(&edit_add_new_friend_id, tox_id, TOX_ADDRESS_SIZE * 2);
-            edit_setstr(&edit_search, (char *)"", 0);
-            flist_selectaddfriend();
-            edit_setfocus(&edit_add_new_friend_msg);
-        }
+    } else if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
+        edit_setstr(&edit_add_new_friend_id, tox_id, TOX_ADDRESS_SIZE * 2);
+        edit_setstr(&edit_search, (char *)"", 0);
+        flist_selectaddfriend();
+        edit_setfocus(&edit_add_new_friend_msg);
     }
 
     return true;

--- a/src/flist.c
+++ b/src/flist.c
@@ -886,6 +886,44 @@ ITEM_TYPE flist_get_type(void) {
     return selected_item->item;
 }
 
+bool get_tox_id_from_uri(const char *str, char *tox_id) {
+    const char *tox_uri_scheme = "tox:";
+    const int tox_uri_scheme_length = 4;
+
+    if (strncmp(str, tox_uri_scheme, tox_uri_scheme_length) == 0 &&
+        strlen(str) - tox_uri_scheme_length == TOX_ADDRESS_SIZE * 2) {
+        memcpy(tox_id, &str[tox_uri_scheme_length], TOX_ADDRESS_SIZE * 2);
+        tox_id[TOX_ADDRESS_SIZE * 2] = '\0';
+        return true;
+    }
+
+    return false;
+}
+
+bool try_open_tox_uri(const char *str) {
+    char tox_id[TOX_ADDRESS_SIZE * 2 + 1];
+
+    if (!get_tox_id_from_uri(str, tox_id)) {
+        return false;
+    }
+
+    FRIEND *friend = get_friend_by_id(tox_id);
+
+    if (friend) {
+        flist_selectchat(friend->number);
+    }
+    else {
+        if (tox_thread_init == UTOX_TOX_THREAD_INIT_SUCCESS) {
+            edit_setstr(&edit_add_new_friend_id, tox_id, TOX_ADDRESS_SIZE * 2);
+            edit_setstr(&edit_search, (char *)"", 0);
+            flist_selectaddfriend();
+            edit_setfocus(&edit_add_new_friend_msg);
+        }
+    }
+
+    return true;
+}
+
 /******************************************************************************
  ****** UI functions                                                     ******
  ******************************************************************************/

--- a/src/flist.c
+++ b/src/flist.c
@@ -886,7 +886,15 @@ ITEM_TYPE flist_get_type(void) {
     return selected_item->item;
 }
 
-bool get_tox_id_from_uri(const char *str, char *tox_id) {
+/**
+ * @brief Extract string ToxId from Tox URI.
+ *
+ * @param str Null-terminated Tox URI.
+ * @param tox_id Extracted ToxId; it has to be at least TOX_ADDRESS_SIZE * 2 + 1.
+ *
+ * @return True if success false otherwise.
+ */
+static bool get_tox_id_from_uri(const char *str, char *tox_id) {
     const char *tox_uri_scheme = "tox:";
     const int tox_uri_scheme_length = 4;
 

--- a/src/flist.h
+++ b/src/flist.h
@@ -69,6 +69,8 @@ FREQUEST *flist_get_frequest(void);
 GROUPCHAT *flist_get_groupchat(void);
 ITEM_TYPE flist_get_type(void);
 
+bool try_open_tox_uri(const char *str);
+
 /* UI functions */
 void flist_draw(void *n, int x, int y, int width, int height);
 bool flist_mmove(void *n, int x, int y, int width, int height, int mx, int my, int dx, int dy);

--- a/src/friend.c
+++ b/src/friend.c
@@ -545,7 +545,7 @@ FRIEND *get_friend_by_id(const char *id_str) {
             continue;
         }
 
-        if (strcmp2(f->id_str, id_str) == 0) {
+        if (strncmp(f->id_str, id_str, TOX_PUBLIC_KEY_SIZE * 2) == 0) {
             return f;
         }
     }

--- a/src/friend.c
+++ b/src/friend.c
@@ -537,6 +537,22 @@ FRIEND *find_friend_by_name(uint8_t *name) {
     return NULL;
 }
 
+FRIEND *get_friend_by_id(const char *id_str) {
+    for (size_t i = 0; i < self.friend_list_count; i++) {
+        FRIEND *f = get_friend(i);
+        if (!f) {
+            LOG_ERR("Friend", "Could not get friend %u", i);
+            continue;
+        }
+
+        if (strcmp2(f->id_str, id_str) == 0) {
+            return f;
+        }
+    }
+
+    return NULL;
+}
+
 void friend_notify_status(FRIEND *f, const uint8_t *msg, size_t msg_length, char *state) {
     if (!settings.status_notifications) {
         return;

--- a/src/friend.h
+++ b/src/friend.h
@@ -121,6 +121,8 @@ uint8_t addfriend_status;
  */
 FRIEND *get_friend(uint32_t friend_number);
 
+FRIEND *get_friend_by_id(const char *id_str);
+
 FREQUEST *get_frequest(uint16_t frequest_number);
 
 /* Add a new friend request */

--- a/src/macros.h
+++ b/src/macros.h
@@ -18,7 +18,6 @@
     ((x) >= (rx) && (y) >= (ry) && (x) < ((rx) + (width)) && (y) < ((ry) + (height)))
 
 // This is hacky and almost never better, try to use an alternative.
-#define strcmp2(x, y) (memcmp(x, y, sizeof(y) - 1))
 #define strcpy2(x, y) (memcpy(x, y, sizeof(y) - 1))
 
 // Is the video stream just a selection of the desktop

--- a/src/messages.c
+++ b/src/messages.c
@@ -1150,13 +1150,13 @@ static bool messages_mmove_text(MESSAGES *m, int width, int mx, int my, int dy, 
     char *end = message + msg_length;
     while (str != end && *str != ' ' && *str != '\n') {
         if (str == message || *(str - 1) == '\n' || *(str - 1) == ' ') {
-            if (m->cursor_over_uri == UINT32_MAX && end - str >= 7 && (strcmp2(str, "http://") == 0)) {
+            if (m->cursor_over_uri == UINT32_MAX && end - str >= 7 && (strncmp(str, "http://", 7) == 0)) {
                 cursor             = CURSOR_HAND;
                 m->cursor_over_uri = str - message;
-            } else if (m->cursor_over_uri == UINT32_MAX && end - str >= 8 && (strcmp2(str, "https://") == 0)) {
+            } else if (m->cursor_over_uri == UINT32_MAX && end - str >= 8 && (strncmp(str, "https://", 8) == 0)) {
                 cursor             = CURSOR_HAND;
                 m->cursor_over_uri = str - message;
-            } else if (m->cursor_over_uri == UINT32_MAX && end - str >= 4 && (strcmp2(str, "tox:") == 0)) {
+            } else if (m->cursor_over_uri == UINT32_MAX && end - str >= 4 && (strncmp(str, "tox:", 4) == 0)) {
                 cursor             = CURSOR_HAND;
                 m->cursor_over_uri = str - message;
             }

--- a/src/messages.c
+++ b/src/messages.c
@@ -1156,6 +1156,9 @@ static bool messages_mmove_text(MESSAGES *m, int width, int mx, int my, int dy, 
             } else if (m->cursor_over_uri == UINT32_MAX && end - str >= 8 && (strcmp2(str, "https://") == 0)) {
                 cursor             = CURSOR_HAND;
                 m->cursor_over_uri = str - message;
+            } else if (m->cursor_over_uri == UINT32_MAX && end - str >= 4 && (strcmp2(str, "tox:") == 0)) {
+                cursor             = CURSOR_HAND;
+                m->cursor_over_uri = str - message;
             }
         }
         str++;

--- a/src/ui/text.c
+++ b/src/ui/text.c
@@ -96,8 +96,8 @@ int utox_draw_text_multiline_within_box(int x, int y, /* x, y of the top left co
 
             if ((a_mark == data || *(a_mark - 1) == '\n' || *(a_mark - 1) == ' ')
                 && (   (end - a_mark >= 7 && memcmp(a_mark, "http://", 7) == 0)
-                    || (end - a_mark >= 8 && memcmp(a_mark, "https://", 8) == 0))
-
+                    || (end - a_mark >= 8 && memcmp(a_mark, "https://", 8) == 0)
+                    || (end - a_mark >= 8 && memcmp(a_mark, "tox:", 4) == 0))
             ) {
                 c2   = setcolor(COLOR_MAIN_TEXT_URL);
                 link = 1;

--- a/src/ui/text.c
+++ b/src/ui/text.c
@@ -97,7 +97,7 @@ int utox_draw_text_multiline_within_box(int x, int y, /* x, y of the top left co
             if ((a_mark == data || *(a_mark - 1) == '\n' || *(a_mark - 1) == ' ')
                 && (   (end - a_mark >= 7 && memcmp(a_mark, "http://", 7) == 0)
                     || (end - a_mark >= 8 && memcmp(a_mark, "https://", 8) == 0)
-                    || (end - a_mark >= 8 && memcmp(a_mark, "tox:", 4) == 0))
+                    || (end - a_mark >= 4 && memcmp(a_mark, "tox:", 4) == 0))
             ) {
                 c2   = setcolor(COLOR_MAIN_TEXT_URL);
                 link = 1;

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -232,12 +232,6 @@ uint64_t get_time(void) {
     return ((uint64_t)clock() * 1000 * 1000);
 }
 
-void openurl(char *str) {
-    wchar_t url[UTOX_FILE_NAME_LENGTH] = { 0 };
-    utf8tonative(str, url, UTOX_FILE_NAME_LENGTH);
-    ShellExecuteW(NULL, L"open", url, NULL, NULL, SW_SHOW);
-}
-
 void setselection(char *UNUSED(data), uint16_t UNUSED(length)) {
     // TODO: Implement.
 }
@@ -511,6 +505,17 @@ void update_tray(void) {
 
 void force_redraw(void) {
     redraw();
+}
+
+void openurl(char *str) {
+    if (try_open_tox_uri(str)) {
+        redraw();
+        return;
+    }
+
+    wchar_t url[UTOX_FILE_NAME_LENGTH] = { 0 };
+    utf8tonative(str, url, UTOX_FILE_NAME_LENGTH);
+    ShellExecuteW(NULL, L"open", url, NULL, NULL, SW_SHOW);
 }
 
 void freefonts() {

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -209,6 +209,11 @@ uint64_t get_time(void) {
 }
 
 void openurl(char *str) {
+    if (try_open_tox_uri(str)) {
+        redraw();
+        return;
+    }
+
     char *cmd = "xdg-open";
     if (!fork()) {
         execlp(cmd, cmd, str, (char *)0);


### PR DESCRIPTION
See #326.

After clicking on [Tox URI](https://wiki.tox.chat/users/toxlinks):
* if you have contact with such ToxId you will be swiched to chat with him
* otherwise a friend request page will be open with filled ToxId

Implemented for all OS that support `openurl` function (Win, Linux, macOS).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1028)
<!-- Reviewable:end -->
