### PR TITLE
fix tray icon not showing in Linux

### DIFF
--- a/src/xlib/tray.c
+++ b/src/xlib/tray.c
@@ -91,8 +91,8 @@ static void draw_tray_icon(void) {
     LOG_NOTE("XLib Tray", "Draw Tray");
 
     uint16_t width, height;
-    uint8_t *icon_data = (uint8_t *)&_binary_icons_utox_128x128_png_start;
-    size_t   icon_size = (size_t)&_binary_icons_utox_128x128_png_size;
+    uint8_t *icon_data = &_binary_icons_utox_128x128_png_start;
+    size_t   icon_size = _binary_icons_utox_128x128_png_size;
 
     NATIVE_IMAGE *icon = utox_image_to_native(icon_data, icon_size, &width, &height, 0);
     if (NATIVE_IMAGE_IS_VALID(icon)) {


### PR DESCRIPTION
The binary icon size was used as pointer instead of using it as the
actual value for the size. Also removed casts for
_binary_icons_utox_128x128_png_start and
_binary_icons_utox_128x128_png_size as they should not be needed here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1050)
<!-- Reviewable:end -->
