### PR TITLE
Don't look for all Toxcore libs by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,18 +262,26 @@ if(ENABLE_AUTOUPDATE)
     add_cflag("-DENABLE_AUTOUPDATE=1")
 endif()
 
-find_package(libtox REQUIRED COMPONENTS
-    toxencryptsave
-    toxav
-    toxcore
-    toxgroup
-    toxmessenger
-    toxfriends
-    toxdht
-    toxnetcrypto
-    toxcrypto
-    toxnetwork
-)
+if(TOXCORE_STATIC)
+    find_package(libtox REQUIRED COMPONENTS
+        toxencryptsave
+        toxav
+        toxcore
+        toxgroup
+        toxmessenger
+        toxfriends
+        toxdht
+        toxnetcrypto
+        toxcrypto
+        toxnetwork
+    )
+else()
+    find_package(libtox REQUIRED COMPONENTS
+        toxencryptsave
+        toxav
+        toxcore
+    )
+endif()
 
 include_directories(${LIBTOX_INCLUDE_DIRS})
 


### PR DESCRIPTION
Apparently cmake generates one set of libs and autotools another. This change is required to fix some packaging things for our .debs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1056)
<!-- Reviewable:end -->
