### PR TITLE
tray icon fix in d505cb8f was not correct, cleanup

### DIFF
--- a/src/xlib/tray.c
+++ b/src/xlib/tray.c
@@ -14,7 +14,7 @@
 
 // Converted to a binary and linked at build time
 extern uint8_t _binary_icons_utox_128x128_png_start;
-extern size_t  _binary_icons_utox_128x128_png_size;
+extern uint8_t _binary_icons_utox_128x128_png_end;
 
 static void send_message(Display *dpy, /* display */
                   Window w, /* sender (tray window) */
@@ -92,7 +92,7 @@ static void draw_tray_icon(void) {
 
     uint16_t width, height;
     uint8_t *icon_data = &_binary_icons_utox_128x128_png_start;
-    size_t   icon_size = _binary_icons_utox_128x128_png_size;
+    size_t   icon_size = &_binary_icons_utox_128x128_png_end - &_binary_icons_utox_128x128_png_start;
 
     NATIVE_IMAGE *icon = utox_image_to_native(icon_data, icon_size, &width, &height, 0);
     if (NATIVE_IMAGE_IS_VALID(icon)) {


### PR DESCRIPTION
Commit d505cb8f tried to read the icon_size directly from
_binary_icons_utox_128x128_png_size which is wrong.
The way it was done before via &_binary_icons_utox_128x128_png_size is
the correct way to do it.

Unfortunately this is not working anymore on systems with PIE (position
independent executable) enabled by default. This causes the loader to
relocate the absolute symbol _binary_icons_utox_128x128_png_size, which
defeats the purpose of the symbol being absolute.
(See discussion here: [1])

A proper fix would be not to use ld to generate the object file but to
serialize the png file to C code via a helper programm during the build
process. I will look into that.

For now just calculate the icon size from the symbols
_binary_icons_utox_128x128_png_start and
_binary_icons_utox_128x128_png_end.

[1] https://www.reddit.com/r/C_Programming/comments/71qx7t/reading_the_size_of_linked_binary_object_file/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1066)
<!-- Reviewable:end -->
