### PR TITLE
Group chats logging

### DIFF
--- a/src/android/main.c
+++ b/src/android/main.c
@@ -280,7 +280,7 @@ bool native_remove_file(const uint8_t *name, size_t length, bool portable_mode) 
     return 1;
 }
 
-void native_export_chatlog_init(uint32_t friend_number)
+void native_export_chatlog_init(uint32_t chat_number, bool is_chat)
 {   /* Unsupported on Android */ }
 
 bool native_save_image_png(const char *name, const uint8_t *image, const int image_size) {

--- a/src/android/main.c
+++ b/src/android/main.c
@@ -280,7 +280,7 @@ bool native_remove_file(const uint8_t *name, size_t length, bool portable_mode) 
     return 1;
 }
 
-void native_export_chatlog_init(uint32_t chat_number, bool is_chat)
+void native_export_chatlog_init(uint32_t chat_number, bool is_groupchat)
 {   /* Unsupported on Android */ }
 
 bool native_save_image_png(const char *name, const uint8_t *image, const int image_size) {

--- a/src/chatlog.c
+++ b/src/chatlog.c
@@ -239,8 +239,8 @@ bool utox_remove_friend_chatlog(char hex[TOX_PUBLIC_KEY_SIZE * 2]) {
     return utox_remove_file((uint8_t*)name, sizeof(name));
 }
 
-void utox_export_chatlog_init(uint32_t friend_number) {
-    native_export_chatlog_init(friend_number);
+void utox_export_chatlog_init(uint32_t chat_number, bool is_chat) {
+    native_export_chatlog_init(chat_number, is_chat);
 }
 
 void utox_export_chatlog(char hex[TOX_PUBLIC_KEY_SIZE * 2], FILE *dest_file) {

--- a/src/chatlog.c
+++ b/src/chatlog.c
@@ -239,8 +239,8 @@ bool utox_remove_friend_chatlog(char hex[TOX_PUBLIC_KEY_SIZE * 2]) {
     return utox_remove_file((uint8_t*)name, sizeof(name));
 }
 
-void utox_export_chatlog_init(uint32_t chat_number, bool is_chat) {
-    native_export_chatlog_init(chat_number, is_chat);
+void utox_export_chatlog_init(uint32_t chat_number, bool is_groupchat) {
+    native_export_chatlog_init(chat_number, is_groupchat);
 }
 
 void utox_export_chatlog(char hex[TOX_PUBLIC_KEY_SIZE * 2], FILE *dest_file) {

--- a/src/chatlog.h
+++ b/src/chatlog.h
@@ -57,7 +57,7 @@ bool utox_remove_friend_chatlog(char hex[TOX_PUBLIC_KEY_SIZE * 2]);
 /**
  * Setup for exporting the chat log to plain text
  */
-void utox_export_chatlog_init(uint32_t chat_number, bool is_chat);
+void utox_export_chatlog_init(uint32_t chat_number, bool is_groupchat);
 
 /**
  * Export the chat log to plain text

--- a/src/chatlog.h
+++ b/src/chatlog.h
@@ -57,7 +57,7 @@ bool utox_remove_friend_chatlog(char hex[TOX_PUBLIC_KEY_SIZE * 2]);
 /**
  * Setup for exporting the chat log to plain text
  */
-void utox_export_chatlog_init(uint32_t friend_number);
+void utox_export_chatlog_init(uint32_t chat_number, bool is_chat);
 
 /**
  * Export the chat log to plain text

--- a/src/cocoa/interaction.m
+++ b/src/cocoa/interaction.m
@@ -895,7 +895,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     if (is_chat) {
         g = get_group(chat_number);
         if (!g) {
-            LOG_ERR("Cocoa", "Could not get friend with number: %u", chat_number);
+            LOG_ERR("Cocoa", "Could not get group with number: %u", chat_number);
             return;
         }
     } else {

--- a/src/cocoa/interaction.m
+++ b/src/cocoa/interaction.m
@@ -888,11 +888,11 @@ void update_tray(void) {
 
 /* file utils */
 
-void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
+void native_export_chatlog_init(uint32_t chat_number, bool is_groupchat) {
     FRIEND *f = NULL;
     GROUPCHAT *g = NULL;
 
-    if (is_chat) {
+    if (is_groupchat) {
         g = get_group(chat_number);
         if (!g) {
             LOG_ERR("Cocoa", "Could not get group with number: %u", chat_number);
@@ -908,14 +908,14 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
 
     NSSavePanel *picker = [NSSavePanel savePanel];
     NSString *fname = [[NSString alloc]
-        initWithBytesNoCopy:(is_chat ? g->name_length : f->name_length)
-        length:(is_chat ? g->name : f->name)
+        initWithBytesNoCopy:(is_groupchat ? g->name_length : f->name_length)
+        length:(is_groupchat ? g->name : f->name)
         encoding:NSUTF8StringEncoding
         freeWhenDone:NO];
 
     picker.message = [NSString stringWithFormat:NSSTRING_FROM_LOCALIZED(WHERE_TO_SAVE_FILE_PROMPT),
-            is_chat ? g->name_length : f->name_length,
-            is_chat ? g->name : f->name];
+            is_groupchat ? g->name_length : f->name_length,
+            is_groupchat ? g->name : f->name];
 
     picker.nameFieldStringValue = fname;
     [fname release];
@@ -928,7 +928,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
             LOG_ERR("Cocoa", "Could not write to file: %s", destination.path.UTF8String);
             return;
         }
-        utox_export_chatlog(is_chat ? g->id_str : f->id_str, file);
+        utox_export_chatlog(is_groupchat ? g->id_str : f->id_str, file);
     }
 }
 

--- a/src/groups.c
+++ b/src/groups.c
@@ -19,7 +19,6 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tox/tox.h>
 
 static GROUPCHAT *group = NULL;
 
@@ -90,6 +89,15 @@ void group_init(GROUPCHAT *g, uint32_t group_number, bool av_group) {
     g->number   = group_number;
     g->notify   = settings.group_notifications;
     g->av_group = av_group;
+
+    srand(time(NULL));
+    uint8_t random[TOX_PUBLIC_KEY_SIZE];
+    for (uint8_t i = 0; i < TOX_PUBLIC_KEY_SIZE; ++i)
+    {
+        random[i] = rand();
+    }
+    to_hex(g->id_str, random, TOX_PUBLIC_KEY_SIZE);
+
     pthread_mutex_unlock(&messages_lock);
 
     flist_add_group(g);

--- a/src/groups.c
+++ b/src/groups.c
@@ -92,8 +92,7 @@ void group_init(GROUPCHAT *g, uint32_t group_number, bool av_group) {
 
     srand(time(NULL));
     uint8_t random[TOX_PUBLIC_KEY_SIZE];
-    for (uint8_t i = 0; i < TOX_PUBLIC_KEY_SIZE; ++i)
-    {
+    for (uint8_t i = 0; i < TOX_PUBLIC_KEY_SIZE; ++i) {
         random[i] = rand();
     }
     to_hex(g->id_str, random, TOX_PUBLIC_KEY_SIZE);

--- a/src/groups.h
+++ b/src/groups.h
@@ -3,6 +3,8 @@
 
 #include "messages.h"
 
+#include <tox/tox.h>
+
 typedef unsigned int ALuint;
 typedef struct edit_change EDIT_CHANGE;
 
@@ -25,6 +27,8 @@ typedef struct group_peer {
 typedef struct groupchat {
     uint16_t number;
     uint32_t our_peer_number;
+
+    char id_str[TOX_PUBLIC_KEY_SIZE * 2];
 
     bool unread_msg;
 

--- a/src/layout/group.c
+++ b/src/layout/group.c
@@ -88,8 +88,8 @@ static void draw_group_settings(int x, int y, int UNUSED(width), int UNUSED(heig
     setcolor(COLOR_MAIN_TEXT);
     setfont(FONT_SELF_NAME);
 
-    drawstr(x + SCALE(10), y + MAIN_TOP + SCALE(10), GROUP_TOPIC);
-    drawstr(x + SCALE(10), y + MAIN_TOP + SCALE(70), GROUP_NOTIFICATIONS);
+    drawstr(x + SCALE(10), y + SCALE(MAIN_TOP + 10), GROUP_TOPIC);
+    drawstr(x + SCALE(10), y + SCALE(MAIN_TOP + 60), GROUP_NOTIFICATIONS);
 }
 
 static void draw_group_create(int x, int y, int UNUSED(width), int UNUSED(height)) {
@@ -543,6 +543,13 @@ static void e_group_topic_onenter(EDIT *edit) {
 
 static char e_group_topic_data[1024];
 EDIT edit_group_topic = {
+    .panel = {
+        .type   = PANEL_EDIT,
+        .x      = 10,
+        .y      = 88,
+        .width  = -10,
+        .height = 24
+    },
     .data           = e_group_topic_data,
     .maxlength      = sizeof e_group_topic_data - 1,
     .onenter        = e_group_topic_onenter,

--- a/src/layout/group.h
+++ b/src/layout/group.h
@@ -15,7 +15,8 @@ extern PANEL panel_group,
 typedef struct button BUTTON;
 extern BUTTON button_group_audio,
               button_chat_send_group,
-              button_create_group;
+              button_create_group,
+              button_export_chatlog_group;
 
 typedef struct dropdown DROPDOWN;
 extern DROPDOWN dropdown_notify_groupchats;

--- a/src/layout/settings.c
+++ b/src/layout/settings.c
@@ -661,7 +661,18 @@ static void button_export_chatlog_on_mup(void) {
         LOG_ERR("Settings", "Could not get selected friend.");
         return;
     }
-    utox_export_chatlog_init(f->number);
+    utox_export_chatlog_init(f->number, false);
+}
+
+#include "../groups.h"
+static void button_export_chatlog_group_on_mup(void) {
+    GROUPCHAT *g = flist_get_groupchat();
+    if (!g) {
+        LOG_ERR("Settings", "Could not get selected group.");
+        return;
+    }
+
+    utox_export_chatlog_init(g->number, true);
 }
 
 static void button_change_nospam_on_mup(void) {
@@ -845,6 +856,15 @@ BUTTON button_export_chatlog = {
     .bm_fill      = BM_SBUTTON,
     .update       = button_setcolors_success,
     .on_mup       = button_export_chatlog_on_mup,
+    .disabled     = false,
+    .button_text  = {.i18nal = STR_FRIEND_EXPORT_CHATLOG },
+    .tooltip_text = {.i18nal = STR_FRIEND_EXPORT_CHATLOG },
+};
+
+BUTTON button_export_chatlog_group = {
+    .bm_fill      = BM_SBUTTON,
+    .update       = button_setcolors_success,
+    .on_mup       = button_export_chatlog_group_on_mup,
     .disabled     = false,
     .button_text  = {.i18nal = STR_FRIEND_EXPORT_CHATLOG },
     .tooltip_text = {.i18nal = STR_FRIEND_EXPORT_CHATLOG },

--- a/src/layout/settings.c
+++ b/src/layout/settings.c
@@ -862,6 +862,13 @@ BUTTON button_export_chatlog = {
 };
 
 BUTTON button_export_chatlog_group = {
+    .panel = {
+        .type   = PANEL_BUTTON,
+        .x      = 10,
+        .y      = 168,
+        .width  = _BM_SBUTTON_WIDTH,
+        .height = _BM_SBUTTON_HEIGHT
+    },
     .bm_fill      = BM_SBUTTON,
     .update       = button_setcolors_success,
     .on_mup       = button_export_chatlog_group_on_mup,
@@ -1305,6 +1312,13 @@ static UTOX_I18N_STR notifydrops[] = {
 };
 
 DROPDOWN dropdown_notify_groupchats = {
+    .panel = {
+        .type   = PANEL_DROPDOWN,
+        .x      = 10,
+        .y      = 138,
+        .width  = 100,
+        .height = 24
+    },
     .ondisplay = simple_dropdown_ondisplay,
     .onselect  = dropdown_notify_groupchats_onselect,
     .dropcount = COUNTOF(notifydrops),

--- a/src/messages.c
+++ b/src/messages.c
@@ -236,6 +236,7 @@ static bool msg_add_day_notice(MESSAGES *m, time_t last, time_t next) {
 /* TODO leaving this here is a little hacky, but it was the fastest way
  * without considering if I should expose messages_add */
 uint32_t message_add_group(MESSAGES *m, MSG_HEADER *msg) {
+    message_log_to_disk(m, msg);
     return message_add(m, msg);
 }
 
@@ -421,24 +422,31 @@ MSG_HEADER *message_add_type_file(MESSAGES *m, uint32_t file_number, bool incomi
 }
 
 bool message_log_to_disk(MESSAGES *m, MSG_HEADER *msg) {
-    if (m->is_groupchat) {
-        /* We don't support logging groupchats yet */
-        return false;
-    }
-
     if (!settings.logging_enabled) {
         return false;
     }
 
-    FRIEND *f = get_friend(m->id);
+    FRIEND *f = NULL;
+    GROUPCHAT *g = NULL;
 
-    if (!f) {
-        LOG_ERR("Messages", "Could not get friend with number: %u", m->id);
-        return false;
-    }
+    if (m->is_groupchat) {
+        g = get_group(m->id);
 
-    if (f->skip_msg_logging) {
-        return false;
+        if (!g) {
+            LOG_ERR("Messages", "Could not get group with number: %u", m->id);
+            return false;
+        }
+    } else {
+        f = get_friend(m->id);
+
+        if (!f) {
+            LOG_ERR("Messages", "Could not get friend with number: %u", m->id);
+            return false;
+        }
+
+        if (f->skip_msg_logging) {
+            return false;
+        }
     }
 
     LOG_FILE_MSG_HEADER header;
@@ -454,8 +462,8 @@ bool message_log_to_disk(MESSAGES *m, MSG_HEADER *msg) {
                 author_length = self.name_length;
                 author        = self.name;
             } else {
-                author_length = f->name_length;
-                author        = f->name;
+                author_length = m->is_groupchat ? msg->via.grp.author_length : f->name_length;
+                author        = m->is_groupchat ? msg->via.grp.author : f->name;
             }
 
             header.log_version   = LOGFILE_SAVE_VERSION;
@@ -477,7 +485,7 @@ bool message_log_to_disk(MESSAGES *m, MSG_HEADER *msg) {
             memcpy(data + sizeof(header) + author_length, msg->via.txt.msg, msg->via.txt.length);
             strcpy2(data + length - 1, "\n");
 
-            msg->disk_offset = utox_save_chatlog(f->id_str, data, length);
+            msg->disk_offset = utox_save_chatlog(m->is_groupchat ? g->id_str : f->id_str, data, length);
 
             free(data);
             return true;
@@ -486,6 +494,7 @@ bool message_log_to_disk(MESSAGES *m, MSG_HEADER *msg) {
             LOG_NOTE("Messages", "uTox Logging:\tUnsupported message type %i", msg->msg_type);
         }
     }
+
     return false;
 }
 

--- a/src/native/filesys.h
+++ b/src/native/filesys.h
@@ -20,7 +20,8 @@ bool native_move_file(const uint8_t *current_name, const uint8_t *new_name);
 // shows a file chooser to the user and calls utox_export_chatlog in turn
 // TODO not let this depend on chatlogs
 // TODO refactor this to be a simple filechooser which returns the file instead
-void native_export_chatlog_init(uint32_t friend_number);
+void native_export_chatlog_init(uint32_t chat_number, bool is_chat);
+
 // TODO same as for chatlogs, this is mainly native because of the file selector thing
 
 typedef struct msg_header MSG_HEADER;

--- a/src/native/filesys.h
+++ b/src/native/filesys.h
@@ -20,7 +20,7 @@ bool native_move_file(const uint8_t *current_name, const uint8_t *new_name);
 // shows a file chooser to the user and calls utox_export_chatlog in turn
 // TODO not let this depend on chatlogs
 // TODO refactor this to be a simple filechooser which returns the file instead
-void native_export_chatlog_init(uint32_t chat_number, bool is_chat);
+void native_export_chatlog_init(uint32_t chat_number, bool is_groupchat);
 
 // TODO same as for chatlogs, this is mainly native because of the file selector thing
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -301,7 +301,7 @@ void ui_rescale(uint8_t scale) {
     CREATE_BUTTON(accept_friend, -60, -80, _BM_SBUTTON_WIDTH, _BM_SBUTTON_HEIGHT);
 
     /* Friend Settings Page */
-    CREATE_BUTTON(export_chatlog, 10, 208, _BM_SBUTTON_WIDTH, _BM_SBUTTON_HEIGHT);
+    CREATE_BUTTON(export_chatlog, 10, 205, _BM_SBUTTON_WIDTH, _BM_SBUTTON_HEIGHT);
 
     CREATE_EDIT(friend_pubkey,          10, 88, -10, 24);
     CREATE_EDIT(friend_alias,           10, 138, -10, 24);
@@ -310,6 +310,7 @@ void ui_rescale(uint8_t scale) {
 
     /* Group Settings */
     CREATE_EDIT(group_topic, 10, 95, -10, 24);
+    CREATE_BUTTON(export_chatlog_group, 10, 125, _BM_SBUTTON_WIDTH, _BM_SBUTTON_HEIGHT);
 
     /* Friend / Group Page  */
     CREATE_BUTTON(call_decline, -186, 10, _BM_LBUTTON_WIDTH, _BM_LBUTTON_HEIGHT);

--- a/src/ui.c
+++ b/src/ui.c
@@ -308,10 +308,6 @@ void ui_rescale(uint8_t scale) {
 
     CREATE_SWITCH(friend_autoaccept_ft, 10, 168, _BM_SWITCH_WIDTH, _BM_SWITCH_HEIGHT);
 
-    /* Group Settings */
-    CREATE_EDIT(group_topic, 10, 95, -10, 24);
-    CREATE_BUTTON(export_chatlog_group, 10, 125, _BM_SBUTTON_WIDTH, _BM_SBUTTON_HEIGHT); //TODO: Move to layout and fix position
-
     /* Friend / Group Page  */
     CREATE_BUTTON(call_decline, -186, 10, _BM_LBUTTON_WIDTH, _BM_LBUTTON_HEIGHT);
     CREATE_BUTTON(call_audio,   -124, 10, _BM_LBUTTON_WIDTH, _BM_LBUTTON_HEIGHT);

--- a/src/ui.c
+++ b/src/ui.c
@@ -310,7 +310,7 @@ void ui_rescale(uint8_t scale) {
 
     /* Group Settings */
     CREATE_EDIT(group_topic, 10, 95, -10, 24);
-    CREATE_BUTTON(export_chatlog_group, 10, 125, _BM_SBUTTON_WIDTH, _BM_SBUTTON_HEIGHT);
+    CREATE_BUTTON(export_chatlog_group, 10, 125, _BM_SBUTTON_WIDTH, _BM_SBUTTON_HEIGHT); //TODO: Move to layout and fix position
 
     /* Friend / Group Page  */
     CREATE_BUTTON(call_decline, -186, 10, _BM_LBUTTON_WIDTH, _BM_LBUTTON_HEIGHT);

--- a/src/windows/main.7.c
+++ b/src/windows/main.7.c
@@ -19,11 +19,11 @@
 #include <shlobj.h>
 #include <io.h>
 
-void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
+void native_export_chatlog_init(uint32_t chat_number, bool is_groupchat) {
     FRIEND *f = NULL;
     GROUPCHAT *g = NULL;
 
-    if (is_chat) {
+    if (is_groupchat) {
         g = get_group(chat_number);
         if (!g) {
             LOG_ERR("Windows7", "Could not get group with number: %u", chat_number);
@@ -44,8 +44,8 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     }
 
     snprintf(path, UTOX_FILE_NAME_LENGTH, "%.*s.txt",
-             (int)(is_chat ? g->name_length : f->name_length),
-             is_chat ? g->name : f->name);
+             (int)(is_groupchat ? g->name_length : f->name_length),
+             is_groupchat ? g->name : f->name);
 
     wchar_t filepath[UTOX_FILE_NAME_LENGTH] = { 0 };
     utf8_to_nativestr(path, filepath, UTOX_FILE_NAME_LENGTH * 2);
@@ -70,7 +70,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
 
         FILE *file = utox_get_file_simple(path, UTOX_FILE_OPTS_WRITE);
         if (file) {
-            utox_export_chatlog(is_chat ? g->id_str : f->id_str, file);
+            utox_export_chatlog(is_groupchat ? g->id_str : f->id_str, file);
         } else {
             LOG_ERR("Windows7", "Opening file %s failed", path);
         }

--- a/src/windows/main.7.c
+++ b/src/windows/main.7.c
@@ -26,7 +26,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     if (is_chat) {
         g = get_group(chat_number);
         if (!g) {
-            LOG_ERR("Windows7", "Could not get friend with number: %u", chat_number);
+            LOG_ERR("Windows7", "Could not get group with number: %u", chat_number);
             return;
         }
     } else {
@@ -62,7 +62,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     if (GetSaveFileNameW(&ofn)) {
         path = calloc(1, UTOX_FILE_NAME_LENGTH);
         if (!path){
-            LOG_ERR("Windows7", " Could not allocate memory." );
+            LOG_ERR("Windows7", "Could not allocate memory.");
             return;
         }
 
@@ -75,7 +75,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
             LOG_ERR("Windows7", "Opening file %s failed", path);
         }
     } else {
-        LOG_ERR("Windows7", "Unable to open file and export chatlog.");
+        LOG_ERR("Windows7", "Could not open file and export chatlog.");
     }
     free(path);
 }

--- a/src/windows/main.XP.c
+++ b/src/windows/main.XP.c
@@ -15,11 +15,11 @@
 
 #include <io.h>
 
-void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
+void native_export_chatlog_init(uint32_t chat_number, bool is_groupchat) {
     FRIEND *f = NULL;
     GROUPCHAT *g = NULL;
 
-    if (is_chat) {
+    if (is_groupchat) {
         g = get_group(chat_number);
         if (!g) {
             LOG_ERR("WinXP", "Could not get group with number: %u", chat_number);
@@ -40,8 +40,8 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     }
 
     snprintf(path, UTOX_FILE_NAME_LENGTH, "%.*s.txt",
-             (int)(is_chat ? g->name_length : f->name_length),
-             is_chat ? g->name : f->name);
+             (int)(is_groupchat ? g->name_length : f->name_length),
+             is_groupchat ? g->name : f->name);
 
     wchar_t filepath[UTOX_FILE_NAME_LENGTH] = { 0 };
     utf8_to_nativestr(path, filepath, UTOX_FILE_NAME_LENGTH * 2);
@@ -66,7 +66,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
 
         FILE *file = utox_get_file_simple(path, UTOX_FILE_OPTS_WRITE);
         if (file) {
-            utox_export_chatlog(is_chat ? g->id_str : f->id_str, file);
+            utox_export_chatlog(is_groupchat ? g->id_str : f->id_str, file);
         } else {
             LOG_ERR("WinXP", "Opening file %s failed", path);
         }

--- a/src/windows/main.XP.c
+++ b/src/windows/main.XP.c
@@ -4,21 +4,33 @@
 #include "utf8.h"
 
 #include "../chatlog.h"
+#include "../debug.h"
 #include "../file_transfers.h"
 #include "../filesys.h"
 #include "../friend.h"
-#include "../debug.h"
+#include "../groups.h"
 #include "../main.h"
 #include "../tox.h"
 #include "../settings.h"
 
 #include <io.h>
 
-void native_export_chatlog_init(uint32_t friend_number) {
-    FRIEND *f = get_friend(friend_number);
-    if (!f) {
-        LOG_ERR("WinXP", "Could not get friend with number: %u", friend_number);
-        return;
+void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
+    FRIEND *f = NULL;
+    GROUPCHAT *g = NULL;
+
+    if (is_chat) {
+        g = get_group(chat_number);
+        if (!g) {
+            LOG_ERR("Windows7", "Could not get friend with number: %u", chat_number);
+            return;
+        }
+    } else {
+        f = get_friend(chat_number);
+        if (!f) {
+            LOG_ERR("Windows7", "Could not get friend with number: %u", chat_number);
+            return;
+        }
     }
 
     char *path = calloc(1, UTOX_FILE_NAME_LENGTH);
@@ -27,7 +39,9 @@ void native_export_chatlog_init(uint32_t friend_number) {
         return;
     }
 
-    snprintf(path, UTOX_FILE_NAME_LENGTH, "%.*s.txt", (int)f->name_length, f->name);
+    snprintf(path, UTOX_FILE_NAME_LENGTH, "%.*s.txt",
+             (int)(is_chat ? g->name_length : f->name_length),
+             is_chat ? g->name : f->name);
 
     wchar_t filepath[UTOX_FILE_NAME_LENGTH] = { 0 };
     utf8_to_nativestr(path, filepath, UTOX_FILE_NAME_LENGTH * 2);
@@ -52,7 +66,7 @@ void native_export_chatlog_init(uint32_t friend_number) {
 
         FILE *file = utox_get_file_simple(path, UTOX_FILE_OPTS_WRITE);
         if (file) {
-            utox_export_chatlog(f->id_str, file);
+            utox_export_chatlog(is_chat ? g->id_str : f->id_str, file);
         } else {
             LOG_ERR("WinXP", "Opening file %s failed", path);
         }

--- a/src/windows/main.XP.c
+++ b/src/windows/main.XP.c
@@ -22,13 +22,13 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     if (is_chat) {
         g = get_group(chat_number);
         if (!g) {
-            LOG_ERR("Windows7", "Could not get friend with number: %u", chat_number);
+            LOG_ERR("WinXP", "Could not get group with number: %u", chat_number);
             return;
         }
     } else {
         f = get_friend(chat_number);
         if (!f) {
-            LOG_ERR("Windows7", "Could not get friend with number: %u", chat_number);
+            LOG_ERR("WinXP", "Could not get friend with number: %u", chat_number);
             return;
         }
     }
@@ -58,7 +58,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     if (GetSaveFileNameW(&ofn)) {
         path = calloc(1, UTOX_FILE_NAME_LENGTH);
         if (!path){
-            LOG_ERR("WinXP", " Could not allocate memory." );
+            LOG_ERR("WinXP", "Could not allocate memory.");
             return;
         }
 
@@ -71,7 +71,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
             LOG_ERR("WinXP", "Opening file %s failed", path);
         }
     } else {
-        LOG_TRACE("WinXP", "GetSaveFileName() failed" );
+        LOG_ERR("WinXP", "Could not open file and export chatlog.");
     }
     free(path);
 }

--- a/src/windows/main.XP.c
+++ b/src/windows/main.XP.c
@@ -33,36 +33,36 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_groupchat) {
         }
     }
 
-    char *path = calloc(1, UTOX_FILE_NAME_LENGTH);
+    char *path = calloc(1, MAX_PATH);
     if (!path){
         LOG_ERR("WinXP", "Could not allocate memory.");
         return;
     }
 
-    snprintf(path, UTOX_FILE_NAME_LENGTH, "%.*s.txt",
+    snprintf(path, MAX_PATH, "%.*s.txt",
              (int)(is_groupchat ? g->name_length : f->name_length),
              is_groupchat ? g->name : f->name);
 
-    wchar_t filepath[UTOX_FILE_NAME_LENGTH] = { 0 };
-    utf8_to_nativestr(path, filepath, UTOX_FILE_NAME_LENGTH * 2);
+    wchar_t filepath[MAX_PATH] = { 0 };
+    utf8_to_nativestr(path, filepath, MAX_PATH * 2);
 
     OPENFILENAMEW ofn = {
         .lStructSize = sizeof(OPENFILENAMEW),
         .lpstrFilter = L".txt",
         .lpstrFile   = filepath,
-        .nMaxFile    = UTOX_FILE_NAME_LENGTH,
+        .nMaxFile    = MAX_PATH,
         .Flags       = OFN_EXPLORER | OFN_NOCHANGEDIR | OFN_NOREADONLYRETURN | OFN_OVERWRITEPROMPT,
         .lpstrDefExt = L"txt",
     };
 
     if (GetSaveFileNameW(&ofn)) {
-        path = calloc(1, UTOX_FILE_NAME_LENGTH);
+        path = calloc(1, MAX_PATH);
         if (!path){
             LOG_ERR("WinXP", "Could not allocate memory.");
             return;
         }
 
-        native_to_utf8str(filepath, path, UTOX_FILE_NAME_LENGTH);
+        native_to_utf8str(filepath, path, MAX_PATH);
 
         FILE *file = utox_get_file_simple(path, UTOX_FILE_OPTS_WRITE);
         if (file) {
@@ -82,24 +82,24 @@ void native_select_dir_ft(uint32_t fid, uint32_t num, FILE_TRANSFER *file) {
         return;
     }
 
-    wchar_t filepath[UTOX_FILE_NAME_LENGTH] = { 0 };
+    wchar_t filepath[MAX_PATH] = { 0 };
     utf8_to_nativestr((char *)file->name, filepath, file->name_length * 2);
 
     OPENFILENAMEW ofn = {
         .lStructSize = sizeof(OPENFILENAMEW),
         .lpstrFile   = filepath,
-        .nMaxFile    = UTOX_FILE_NAME_LENGTH,
+        .nMaxFile    = MAX_PATH,
         .Flags       = OFN_EXPLORER | OFN_NOCHANGEDIR | OFN_NOREADONLYRETURN | OFN_OVERWRITEPROMPT,
     };
 
     if (GetSaveFileNameW(&ofn)) {
-        char *path = calloc(1, UTOX_FILE_NAME_LENGTH);
+        char *path = calloc(1, MAX_PATH);
         if (!path) {
             LOG_ERR("WinXP", "Could not allocate memory for path.");
             return;
         }
 
-        native_to_utf8str(filepath, path, UTOX_FILE_NAME_LENGTH);
+        native_to_utf8str(filepath, path, MAX_PATH);
         postmessage_toxcore(TOX_FILE_ACCEPT, fid, num, path);
     } else {
         LOG_ERR("WinXP", "GetSaveFileName() failed");
@@ -121,8 +121,8 @@ void native_autoselect_dir_ft(uint32_t fid, FILE_TRANSFER *file) {
         return;
     }
 
-    wchar_t subpath[UTOX_FILE_NAME_LENGTH] = { 0 };
-    swprintf(subpath, UTOX_FILE_NAME_LENGTH, L"%ls%ls", autoaccept_folder, L"\\Tox_Auto_Accept");
+    wchar_t subpath[MAX_PATH] = { 0 };
+    swprintf(subpath, MAX_PATH, L"%ls%ls", autoaccept_folder, L"\\Tox_Auto_Accept");
 
     free(autoaccept_folder);
 
@@ -133,19 +133,19 @@ void native_autoselect_dir_ft(uint32_t fid, FILE_TRANSFER *file) {
         return;
     }
 
-    wchar_t filename[UTOX_FILE_NAME_LENGTH] = { 0 };
+    wchar_t filename[MAX_PATH] = { 0 };
     utf8_to_nativestr((char *)file->name, filename, file->name_length * 2);
 
-    wchar_t fullpath[UTOX_FILE_NAME_LENGTH] = { 0 };
-    swprintf(fullpath, UTOX_FILE_NAME_LENGTH, L"%ls\\%ls", subpath, filename);
+    wchar_t fullpath[MAX_PATH] = { 0 };
+    swprintf(fullpath, MAX_PATH, L"%ls\\%ls", subpath, filename);
 
-    char *path = calloc(1, UTOX_FILE_NAME_LENGTH);
+    char *path = calloc(1, MAX_PATH);
     if (!path) {
         LOG_ERR("WinXP", "Could not allocate memory for path.");
         return;
     }
 
-    native_to_utf8str(fullpath, path, UTOX_FILE_NAME_LENGTH);
+    native_to_utf8str(fullpath, path, MAX_PATH);
     postmessage_toxcore(TOX_FILE_ACCEPT_AUTO, fid, file->file_number, path);
 }
 
@@ -153,10 +153,10 @@ void launch_at_startup(bool should) {
     HKEY hKey;
     const wchar_t *run_key_path = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
 
-    wchar_t path[UTOX_FILE_NAME_LENGTH * 2];
+    wchar_t path[MAX_PATH * 2];
     if (should) {
         if (ERROR_SUCCESS == RegOpenKeyW(HKEY_CURRENT_USER, run_key_path, &hKey)) {
-            uint16_t path_length  = GetModuleFileNameW(NULL, path + 1, UTOX_FILE_NAME_LENGTH * 2);
+            uint16_t path_length  = GetModuleFileNameW(NULL, path + 1, MAX_PATH * 2);
             path[0]               = '\"';
             path[path_length + 1] = '\"';
             path[path_length + 2] = '\0';

--- a/src/xlib/filesys.c
+++ b/src/xlib/filesys.c
@@ -139,7 +139,7 @@ void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
         if (is_chat) {
             g = get_group(chat_number);
             if (!g) {
-                LOG_ERR("Filesys", "Could not get friend with number: %u", chat_number);
+                LOG_ERR("Filesys", "Could not get group with number: %u", chat_number);
                 return;
             }
         } else {

--- a/src/xlib/gtk.c
+++ b/src/xlib/gtk.c
@@ -7,6 +7,7 @@
 #include "../filesys.h"
 #include "../flist.h"
 #include "../friend.h"
+#include "../groups.h"
 #include "../macros.h"
 #include "../stb.h"
 #include "../text.h"
@@ -20,7 +21,6 @@
 
 #include <dlfcn.h>
 #include <errno.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -333,16 +333,33 @@ static void ugtk_save_data_thread(void *args) {
 }
 
 static void ugtk_save_chatlog_thread(void *args) {
-    size_t friend_number = (size_t)args;
-    FRIEND *f = get_friend(friend_number);
-    if (!f) {
-        LOG_ERR("GTK", "Could not get friend with number: %u", friend_number);
-        utoxGTK_open = false;
-        return;
+    CHAT *chat = args;
+
+    FRIEND *f = NULL;
+    GROUPCHAT *g = NULL;
+
+    if (chat->is_groupchat) {
+        g = get_group(chat->chat_number);
+        if (!g) {
+            LOG_ERR("GTK", "Could not get group with number: %u", chat->chat_number);
+            free(chat);
+            utoxGTK_open = false;
+            return;
+        }
+    } else {
+        f = get_friend(chat->chat_number);
+        if (!f) {
+            LOG_ERR("GTK", "Could not get friend with number: %u", chat->chat_number);
+            free(chat);
+            utoxGTK_open = false;
+            return;
+        }
     }
 
     char name[TOX_MAX_NAME_LENGTH + sizeof ".txt"];
-    snprintf(name, sizeof name, "%.*s.txt", (int)f->name_length, f->name);
+    snprintf(name, sizeof name, "%.*s.txt",
+             (int)(chat->is_groupchat ? g->name_length : f->name_length),
+             chat->is_groupchat ? g->name : f->name);
 
     void *dialog = utoxGTK_file_chooser_dialog_new((const char *)S(SAVE_FILE), NULL, GTK_FILE_CHOOSER_ACTION_SAVE,
                                                    "_Cancel", GTK_RESPONSE_CANCEL, "_Save", GTK_RESPONSE_ACCEPT, NULL);
@@ -353,7 +370,7 @@ static void ugtk_save_chatlog_thread(void *args) {
 
         FILE *fp = fopen(file_name, "wb");
         if (fp) {
-            utox_export_chatlog(f->id_str, fp);
+            utox_export_chatlog(chat->is_groupchat ? g->id_str : f->id_str, fp);
         }
     }
 
@@ -363,6 +380,7 @@ static void ugtk_save_chatlog_thread(void *args) {
     }
 
     utoxGTK_open = false;
+    free(chat);
 }
 
 static void ugtk_save_image_png_thread(void *args) {
@@ -451,15 +469,13 @@ void ugtk_file_save_image_png(FILE_IMAGE *image) {
     thread(ugtk_save_image_png_thread, image);
 }
 
-void ugtk_save_chatlog(uint32_t friend_number) {
+void ugtk_save_chatlog(CHAT *chat) {
     if (utoxGTK_open) {
         return;
     }
 
-    // We just care about sending a single uint, but we don't want to overflow a buffer
-    size_t fnum = friend_number;
     utoxGTK_open = true;
-    thread(ugtk_save_chatlog_thread, (void *)fnum); // No need to create and pass a pointer for a single u32
+    thread(ugtk_save_chatlog_thread, chat);
 }
 
 /* macro to link and test each of the gtk functions we need.

--- a/src/xlib/gtk.h
+++ b/src/xlib/gtk.h
@@ -2,10 +2,15 @@
 #define UTOX_GTK_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef struct file_transfer FILE_TRANSFER;
 typedef struct msg_header MSG_HEADER;
-typedef struct file_transfer FILE_TRANSFER;
+
+typedef struct {
+	uint32_t chat_number;
+	bool 	 is_groupchat;
+} CHAT;
 
 typedef struct {
     char *name;
@@ -21,7 +26,7 @@ void ugtk_native_select_dir_ft(uint32_t fid, FILE_TRANSFER *file);
 
 void ugtk_file_save_inline(MSG_HEADER *msg);
 
-void ugtk_save_chatlog(uint32_t friend_number);
+void ugtk_save_chatlog(CHAT *chat);
 
 /**
  * @brief Save passed image to selected file.

--- a/tests/test_chatlog.c
+++ b/tests/test_chatlog.c
@@ -10,7 +10,7 @@
 
 #define MOCK_FRIEND_ID "6460FF76319AF777A999ABA2024D5D0AEB202360688ECBABFE56C9403B872D2F"
 
-void native_export_chatlog_init(uint32_t friend_number) {
+void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
     char* name = strdup("chatlog_export.txt");
     FILE *file = fopen(name, "wb");
     if (file) {

--- a/tests/test_chatlog.c
+++ b/tests/test_chatlog.c
@@ -10,7 +10,7 @@
 
 #define MOCK_FRIEND_ID "6460FF76319AF777A999ABA2024D5D0AEB202360688ECBABFE56C9403B872D2F"
 
-void native_export_chatlog_init(uint32_t chat_number, bool is_chat) {
+void native_export_chatlog_init(uint32_t chat_number, bool is_groupchat) {
     char* name = strdup("chatlog_export.txt");
     FILE *file = fopen(name, "wb");
     if (file) {


### PR DESCRIPTION
Fixes #231.

Since we haven't persistent chats yet, chat log could not be loaded.
So the only case when we need that log is export as plain text which was implemented in that PR.

Also I added unique pseudo-identifier for each new chat. If you are not okay with that I'm looking forward to your options for this.

Merge after #1074 (there will be group settings layout update).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1079)
<!-- Reviewable:end -->
