### PR TITLE
Tox ID as QR code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third-party/minini"]
 	path = third-party/minini
 	url = https://github.com/compuphase/minIni.git
+[submodule "third-party/qrcodegen"]
+	path = third-party/qrcodegen
+	url = https://github.com/nayuki/QR-Code-generator.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,7 @@ add_executable(utox ${GUI_TYPE}
     src/main.c
     src/messages.c
     src/notify.c
+    src/qr.c
     src/screen_grab.c
     src/self.c
     src/settings.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,7 @@ set(LIBRARIES ${LIBRARIES} ${LIBSODIUM_LIBRARIES})
 
 include_directories(SYSTEM third-party/stb)
 include_directories(SYSTEM third-party/minini/dev)
+include_directories(SYSTEM third-party/qrcodegen/c)
 
 # Protip, you must use a different directory for each build target...
 # -DMAKE_TOOLCHAIN_FILE has no effect unless the target directory is empty
@@ -372,6 +373,7 @@ add_executable(utox ${GUI_TYPE}
     src/utox.c
     src/window.c
     third-party/minini/dev/minIni.c
+    third-party/qrcodegen/c/qrcodegen.c
 
     ${WINDOWS_ICON}
     ${APPLE_FILES}

--- a/langs/en.h
+++ b/langs/en.h
@@ -585,6 +585,18 @@ msgstr("Close To Tray")
 msgid(START_IN_TRAY)
 msgstr("Start In Tray")
 
+msgid(SHOW_QR)
+msgstr("Show QR")
+
+msgid(HIDE_QR)
+msgstr("Hide QR")
+
+msgid(SAVE_QR)
+msgstr("Save QR")
+
+msgid(COPY_TOX_ID)
+msgstr("Copy as text")
+
 msgid(COPY)
 msgstr("Copy")
 

--- a/langs/i18n_decls.h
+++ b/langs/i18n_decls.h
@@ -136,6 +136,9 @@ typedef enum {
     /* TODO REMOVE OLD ONES! */
     STR_ADDFRIENDS,
     STR_TOXID,
+    STR_SHOW_QR,
+    STR_HIDE_QR,
+    STR_SAVE_QR,
     STR_MESSAGE,
     STR_FILTER_ALL,
     STR_FILTER_ONLINE,
@@ -213,7 +216,7 @@ typedef enum {
 
     // Interact with texts / clipboard
     STR_COPY,
-    STR_COPY_TOX_ID = STR_COPY,
+    STR_COPY_TOX_ID,
     STR_COPYWITHOUTNAMES,
     STR_COPY_WITH_NAMES,
     STR_CUT,

--- a/langs/ru.h
+++ b/langs/ru.h
@@ -503,6 +503,18 @@ msgstr("Сворачивать вместо закрытия")
 msgid(START_IN_TRAY)
 msgstr("Запускать свёрнутым")
 
+msgid(SHOW_QR)
+msgstr("Показать QR")
+
+msgid(HIDE_QR)
+msgstr("Скрыть QR")
+
+msgid(SAVE_QR)
+msgstr("Сохранить QR")
+
+msgid(COPY_TOX_ID)
+msgstr("Копировать как текст")
+
 msgid(COPY)
 msgstr("Копировать")
 

--- a/src/android/main.c
+++ b/src/android/main.c
@@ -283,6 +283,10 @@ bool native_remove_file(const uint8_t *name, size_t length, bool portable_mode) 
 void native_export_chatlog_init(uint32_t friend_number)
 {   /* Unsupported on Android */ }
 
+bool native_save_image_png(const char *name, const uint8_t *image, const int image_size) {
+    /* Unsupported on Android */
+}
+
 void flush_file(FILE *file) {
     fflush(file);
     int fd = fileno(file);

--- a/src/cocoa/interaction.m
+++ b/src/cocoa/interaction.m
@@ -976,6 +976,28 @@ void file_save_inline_image_png(MSG_HEADER *msg) {
         msg->via.ft.inline_png = false;
     }
 }
+
+bool native_save_image_png(const char *name, const uint8_t *image, const int image_size) {
+    NSSavePanel *picker = [NSSavePanel savePanel];
+    NSString *fname =
+        [[NSString alloc] initWithBytes:name length:strlen(name) encoding:NSUTF8StringEncoding];
+    picker.message = [NSString
+        stringWithFormat:NSSTRING_FROM_LOCALIZED(WHERE_TO_SAVE_FILE_PROMPT), strlen(name), name];
+    picker.nameFieldStringValue = fname;
+    [fname release];
+    int ret = [picker runModal];
+
+    if (ret == NSFileHandlingPanelOKButton) {
+        NSURL  *destination = picker.URL;
+        NSData *d = [NSData dataWithBytesNoCopy:image length:image_size freeWhenDone:NO];
+        [d writeToURL:destination atomically:YES];
+
+        return true;
+    }
+
+    return false;
+}
+
 //@"Select one or more files to send."
 void openfilesend(void) {
     NSOpenPanel *picker            = [NSOpenPanel openPanel];

--- a/src/cocoa/interaction.m
+++ b/src/cocoa/interaction.m
@@ -984,6 +984,7 @@ bool native_save_image_png(const char *name, const uint8_t *image, const int ima
     picker.message = [NSString
         stringWithFormat:NSSTRING_FROM_LOCALIZED(WHERE_TO_SAVE_FILE_PROMPT), strlen(name), name];
     picker.nameFieldStringValue = fname;
+    picker.allowedFileTypes = @[ @"png" ];
     [fname release];
     int ret = [picker runModal];
 

--- a/src/layout/settings.c
+++ b/src/layout/settings.c
@@ -152,7 +152,7 @@ static void draw_settings_text_profile(int x, int y, int UNUSED(w), int UNUSED(h
     if (self.qr_image && !button_qr.disabled) {
         // Enlarge original QR for better recognition
         const double image_scale = SCALE(4);
-        const uint32_t image_size = self.qr_data_size * image_scale;
+        const uint32_t image_size = self.qr_image_size * image_scale;
 
         button_qr.panel.width = button_qr.panel.height = UN_SCALE(self.qr_image_size * image_scale);
 
@@ -711,7 +711,6 @@ static void button_show_qr_on_mup(void) {
 
 static void contextmenu_qr_onselect(uint8_t i) {
     if (i == 0) {
-        LOG_ERR("Settings", "name=%s", self.name);
         if (!native_save_image_png(self.name, self.qr_data, self.qr_data_size)) {
             LOG_ERR("Self", "Unable to save QR code.");
         }

--- a/src/layout/settings.h
+++ b/src/layout/settings.h
@@ -33,6 +33,8 @@ extern BUTTON   button_add_new_device_to_self;
 extern BUTTON   button_callpreview,
                 button_videopreview,
                 button_copyid,
+                button_show_qr,
+                button_qr,
                 button_lock_uTox,
                 button_show_password_settings,
                 button_change_nospam,

--- a/src/native/filesys.h
+++ b/src/native/filesys.h
@@ -22,9 +22,13 @@ bool native_move_file(const uint8_t *current_name, const uint8_t *new_name);
 // TODO refactor this to be a simple filechooser which returns the file instead
 void native_export_chatlog_init(uint32_t friend_number);
 // TODO same as for chatlogs, this is mainly native because of the file selector thing
+
 typedef struct msg_header MSG_HEADER;
 void file_save_inline_image_png(MSG_HEADER *msg);
 // TODO same as for chatlogs, this is mainly native because of the file selector thing
+
+bool native_save_image_png(const char *name, const uint8_t *image, const int image_size);
+
 typedef struct file_transfer FILE_TRANSFER;
 void native_autoselect_dir_ft(uint32_t fid, FILE_TRANSFER *file);
 void native_select_dir_ft(uint32_t fid, uint32_t num, FILE_TRANSFER *file);

--- a/src/qr.c
+++ b/src/qr.c
@@ -1,0 +1,58 @@
+#include "qr.h"
+
+#include "debug.h"
+#include "stb.h"
+
+#include <qrcodegen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static bool generate_qr(const char *text, uint8_t *qrcode) {
+    uint8_t temp_buffer[qrcodegen_BUFFER_LEN_MAX];
+    return qrcodegen_encodeText(text, temp_buffer, qrcode, qrcodegen_Ecc_MEDIUM,
+        qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX, qrcodegen_Mask_AUTO, true);
+}
+
+static void convert_qr_to_rgb(const uint8_t *qrcode, uint8_t size, uint8_t *pixels) {
+    uint16_t i = 0;
+    for (uint8_t y = 0; y < size; y++) {
+        for (uint8_t x = 0; x < size; x++) {
+            bool black = qrcodegen_getModule(qrcode, x, y);
+            pixels[i] = pixels[i + 1] = pixels[i + 2] = black ? 0x00 : 0xFF;
+            i += 3;
+        }
+    }
+}
+
+void qr_setup(const char *id_str,
+              uint8_t **qr_data,
+              int *qr_data_size,
+              NATIVE_IMAGE **qr_image,
+              int *qr_image_size) {
+    const char *tox_uri_scheme = "tox:";
+    const int tox_uri_scheme_length = 4;
+    const uint8_t channel_number = 3;
+    const uint8_t tox_uri_length = TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length + 1;
+
+    char tox_uri[tox_uri_length];
+    memset(tox_uri, 0, tox_uri_length);
+    strcat(tox_uri, tox_uri_scheme);
+    strcat(tox_uri, id_str);
+
+    uint8_t qrcode[qrcodegen_BUFFER_LEN_MAX] = { 0 };
+    if (!generate_qr(tox_uri, qrcode)) {
+        LOG_ERR("QR", "Unable to generate QR code from Tox URI.");
+        return;
+    }
+
+    *qr_image_size = qrcodegen_getSize(qrcode);
+    uint8_t pixels[*qr_image_size * *qr_image_size * channel_number];
+    memset(pixels, 0, *qr_image_size * *qr_image_size * channel_number);
+    convert_qr_to_rgb(qrcode, *qr_image_size, pixels);
+
+    *qr_data = stbi_write_png_to_mem(pixels, 0, *qr_image_size, *qr_image_size, channel_number, qr_data_size);
+
+    uint16_t native_size = *qr_image_size;
+    *qr_image = utox_image_to_native(*qr_data, *qr_data_size, &native_size, &native_size, false);
+}

--- a/src/qr.c
+++ b/src/qr.c
@@ -2,6 +2,9 @@
 
 #include "debug.h"
 #include "stb.h"
+#include "tox.h"
+
+#include "native/image.h"
 
 #include <qrcodegen.h>
 #include <stdio.h>
@@ -30,10 +33,9 @@ void qr_setup(const char *id_str,
               int *qr_data_size,
               NATIVE_IMAGE **qr_image,
               int *qr_image_size) {
-    const char *tox_uri_scheme = "tox:";
-    const int tox_uri_scheme_length = 4;
+    const char tox_uri_scheme[] = "tox:";
     const uint8_t channel_number = 3;
-    const uint8_t tox_uri_length = TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length + 1;
+    const uint8_t tox_uri_length = TOX_ADDRESS_SIZE * 2 + sizeof(tox_uri_scheme);
 
     char tox_uri[tox_uri_length];
     memset(tox_uri, 0, tox_uri_length);

--- a/src/qr.h
+++ b/src/qr.h
@@ -1,0 +1,8 @@
+#include "tox.h"
+#include "native/image.h"
+
+void qr_setup(const char *id_str,
+              uint8_t **qr_data,
+              int *qr_data_size,
+              NATIVE_IMAGE **qr_image,
+              int *qr_image_size);

--- a/src/qr.h
+++ b/src/qr.h
@@ -1,5 +1,6 @@
-#include "tox.h"
-#include "native/image.h"
+#include <stdint.h>
+
+typedef struct native_image NATIVE_IMAGE;
 
 void qr_setup(const char *id_str,
               uint8_t **qr_data,

--- a/src/self.c
+++ b/src/self.c
@@ -38,9 +38,10 @@ void qr_setup() {
     const char *tox_uri_scheme = "tox:";
     const int tox_uri_scheme_length = 4;
     const uint8_t channel_number = 3;
+    const uint8_t tox_uri_length = TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length + 1;
 
-    char tox_uri[TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length];
-    memset(tox_uri, 0, TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length);
+    char tox_uri[tox_uri_length];
+    memset(tox_uri, 0, tox_uri_length);
     strcat(tox_uri, tox_uri_scheme);
     strcat(tox_uri, self.id_str);
 

--- a/src/self.c
+++ b/src/self.c
@@ -2,12 +2,64 @@
 
 #include "avatar.h"
 #include "debug.h"
+#include "stb.h"
 #include "tox.h"
 
 #include "ui/edit.h"
 #include "layout/settings.h"
+#include "native/filesys.h"
+
+#include "qrcodegen.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static bool generate_qr(const char *text, uint8_t *qrcode) {
+    uint8_t tempBuffer[qrcodegen_BUFFER_LEN_MAX];
+    return qrcodegen_encodeText(text, tempBuffer, qrcode, qrcodegen_Ecc_MEDIUM,
+        qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX, qrcodegen_Mask_AUTO, true);
+}
+
+static void convert_qr_to_rgb(uint8_t *qrcode, uint8_t size, uint8_t *pixels) {
+    uint16_t i = 0;
+    for (uint8_t y = 0; y < size; y++) {
+        for (uint8_t x = 0; x < size; x++) {
+            bool black = qrcodegen_getModule(qrcode, x, y);
+            pixels[i] = black ? 0x00 : 0xFF;
+            pixels[i + 1] = black ? 0x00 : 0xFF;
+            pixels[i + 2] = black ? 0x00 : 0xFF;
+            i += 3;
+        }
+    }
+}
+
+void qr_setup() {
+    const char *tox_uri_scheme = "tox:";
+    const int tox_uri_scheme_length = 4;
+    const uint8_t channel_number = 3;
+
+    char tox_uri[TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length];
+    memset(tox_uri, 0, TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length);
+    strcat(tox_uri, tox_uri_scheme);
+    strcat(tox_uri, self.id_str);
+
+    uint8_t qrcode[qrcodegen_BUFFER_LEN_MAX] = { 0 };
+    if (!generate_qr(tox_uri, qrcode)) {
+        LOG_ERR("Self", "Unable to generate QR code from Tox URI.");
+        return;
+    }
+
+    self.qr_image_size = qrcodegen_getSize(qrcode);
+    uint8_t pixels[self.qr_image_size * self.qr_image_size * channel_number];
+    memset(pixels, 0, self.qr_image_size * self.qr_image_size * channel_number);
+    convert_qr_to_rgb(qrcode, self.qr_image_size, pixels);
+
+    self.qr_data = stbi_write_png_to_mem(pixels, 0, self.qr_image_size, self.qr_image_size, channel_number, &self.qr_data_size);
+
+    uint16_t native_size = self.qr_image_size;
+    self.qr_image = utox_image_to_native(self.qr_data, self.qr_data_size, &native_size, &native_size, false);
+}
 
 void init_self(Tox *tox) {
     /* Set local info for self */
@@ -19,6 +71,8 @@ void init_self(Tox *tox) {
     id_to_string(self.id_str, self.id_binary);
     self.id_str_length = TOX_ADDRESS_SIZE * 2;
     LOG_TRACE("Self INIT", "Tox ID: %.*s" , (int)self.id_str_length, self.id_str);
+
+    qr_setup();
 
     /* Get nospam */
     self.nospam = tox_self_get_nospam(tox);

--- a/src/self.c
+++ b/src/self.c
@@ -2,65 +2,16 @@
 
 #include "avatar.h"
 #include "debug.h"
-#include "stb.h"
+#include "qr.h"
 #include "tox.h"
 
 #include "ui/edit.h"
 #include "layout/settings.h"
 #include "native/filesys.h"
 
-#include "qrcodegen.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-static bool generate_qr(const char *text, uint8_t *qrcode) {
-    uint8_t tempBuffer[qrcodegen_BUFFER_LEN_MAX];
-    return qrcodegen_encodeText(text, tempBuffer, qrcode, qrcodegen_Ecc_MEDIUM,
-        qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX, qrcodegen_Mask_AUTO, true);
-}
-
-static void convert_qr_to_rgb(uint8_t *qrcode, uint8_t size, uint8_t *pixels) {
-    uint16_t i = 0;
-    for (uint8_t y = 0; y < size; y++) {
-        for (uint8_t x = 0; x < size; x++) {
-            bool black = qrcodegen_getModule(qrcode, x, y);
-            pixels[i] = black ? 0x00 : 0xFF;
-            pixels[i + 1] = black ? 0x00 : 0xFF;
-            pixels[i + 2] = black ? 0x00 : 0xFF;
-            i += 3;
-        }
-    }
-}
-
-void qr_setup() {
-    const char *tox_uri_scheme = "tox:";
-    const int tox_uri_scheme_length = 4;
-    const uint8_t channel_number = 3;
-    const uint8_t tox_uri_length = TOX_ADDRESS_SIZE * 2 + tox_uri_scheme_length + 1;
-
-    char tox_uri[tox_uri_length];
-    memset(tox_uri, 0, tox_uri_length);
-    strcat(tox_uri, tox_uri_scheme);
-    strcat(tox_uri, self.id_str);
-
-    uint8_t qrcode[qrcodegen_BUFFER_LEN_MAX] = { 0 };
-    if (!generate_qr(tox_uri, qrcode)) {
-        LOG_ERR("Self", "Unable to generate QR code from Tox URI.");
-        return;
-    }
-
-    self.qr_image_size = qrcodegen_getSize(qrcode);
-    uint8_t pixels[self.qr_image_size * self.qr_image_size * channel_number];
-    memset(pixels, 0, self.qr_image_size * self.qr_image_size * channel_number);
-    convert_qr_to_rgb(qrcode, self.qr_image_size, pixels);
-
-    self.qr_data = stbi_write_png_to_mem(pixels, 0, self.qr_image_size, self.qr_image_size, channel_number, &self.qr_data_size);
-
-    uint16_t native_size = self.qr_image_size;
-    self.qr_image = utox_image_to_native(self.qr_data, self.qr_data_size, &native_size, &native_size, false);
-}
 
 void init_self(Tox *tox) {
     /* Set local info for self */
@@ -73,7 +24,7 @@ void init_self(Tox *tox) {
     self.id_str_length = TOX_ADDRESS_SIZE * 2;
     LOG_TRACE("Self INIT", "Tox ID: %.*s" , (int)self.id_str_length, self.id_str);
 
-    qr_setup();
+    qr_setup(self.id_str, &self.qr_data, &self.qr_data_size, &self.qr_image, &self.qr_image_size);
 
     /* Get nospam */
     self.nospam = tox_self_get_nospam(tox);

--- a/src/self.h
+++ b/src/self.h
@@ -2,6 +2,7 @@
 #define SELF_H
 
 #include <tox/tox.h>
+#include "native/image.h"
 
 typedef struct avatar AVATAR;
 
@@ -22,6 +23,12 @@ struct utox_self {
 
     char   id_str[TOX_ADDRESS_SIZE * 2];
     size_t id_str_length;
+
+    NATIVE_IMAGE *qr_image;
+    int qr_data_size;
+
+    uint8_t *qr_data;
+    int qr_image_size;
 
     uint8_t id_binary[TOX_ADDRESS_SIZE];
 

--- a/src/self.h
+++ b/src/self.h
@@ -25,10 +25,10 @@ struct utox_self {
     size_t id_str_length;
 
     NATIVE_IMAGE *qr_image;
-    int qr_data_size;
+    int qr_image_size;
 
     uint8_t *qr_data;
-    int qr_image_size;
+    int qr_data_size;
 
     uint8_t id_binary[TOX_ADDRESS_SIZE];
 

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -1,5 +1,4 @@
 #include "main.h"
-
 #include "notify.h"
 #include "screen_grab.h"
 #include "utf8.h"
@@ -235,16 +234,16 @@ bool native_save_image_png(const char *name, const uint8_t *image, const int ima
         native_to_utf8str(filepath, path, UTOX_FILE_NAME_LENGTH);
 
         FILE *file = utox_get_file_simple(path, UTOX_FILE_OPTS_WRITE);
-        if (file) {
-            fwrite(image, image_size, 1, file);
-            fclose(file);
-            free(path);
-            return true;
-        } else {
+        if (!file) {
             LOG_ERR("NATIVE", "Could not open file %s for write.", path);
             free(path);
             return false;
         }
+
+        fwrite(image, image_size, 1, file);
+        fclose(file);
+        free(path);
+        return true;
     }
 
     return false;

--- a/src/xlib/filesys.c
+++ b/src/xlib/filesys.c
@@ -230,6 +230,31 @@ void file_save_inline_image_png(MSG_HEADER *msg) {
     }
 }
 
+bool native_save_image_png(char *name, uint8_t *image, int image_size) {
+    if (libgtk) {
+        FILE_IMAGE *file_image = calloc(1, sizeof(FILE_IMAGE));
+        file_image->name       = name;
+        file_image->data       = image;
+        file_image->data_size  = image_size;
+
+        ugtk_file_save_image_png(file_image);
+        return true;
+    } else {
+        char path[TOX_MAX_NAME_LENGTH + sizeof(".png")] = { 0 };
+        snprintf(path, sizeof(path), "%s.png", name);
+
+        FILE *file = fopen(path, "wb");
+        if (!file) {
+            LOG_ERR("Native", "Could not open file %s for write.", path);
+            return false;
+        }
+
+        fwrite(image, image_size, 1, file);
+        fclose(file);
+        return true;
+    }
+}
+
 int file_lock(FILE *file, uint64_t start, size_t length) {
     struct flock fl;
     fl.l_type   = F_WRLCK;

--- a/src/xlib/filesys.c
+++ b/src/xlib/filesys.c
@@ -244,20 +244,20 @@ bool native_save_image_png(char *name, uint8_t *image, int image_size) {
 
         ugtk_file_save_image_png(file_image);
         return true;
-    } else {
-        char path[TOX_MAX_NAME_LENGTH + sizeof(".png")] = { 0 };
-        snprintf(path, sizeof(path), "%s.png", name);
-
-        FILE *file = fopen(path, "wb");
-        if (!file) {
-            LOG_ERR("Native", "Could not open file %s for write.", path);
-            return false;
-        }
-
-        fwrite(image, image_size, 1, file);
-        fclose(file);
-        return true;
     }
+
+    char path[TOX_MAX_NAME_LENGTH + sizeof(".png")] = { 0 };
+    snprintf(path, sizeof(path), "%s.png", name);
+
+    FILE *file = fopen(path, "wb");
+    if (!file) {
+        LOG_ERR("Native", "Could not open file %s for write.", path);
+        return false;
+    }
+
+    fwrite(image, image_size, 1, file);
+    fclose(file);
+    return true;
 }
 
 int file_lock(FILE *file, uint64_t start, size_t length) {

--- a/src/xlib/filesys.c
+++ b/src/xlib/filesys.c
@@ -233,6 +233,11 @@ void file_save_inline_image_png(MSG_HEADER *msg) {
 bool native_save_image_png(char *name, uint8_t *image, int image_size) {
     if (libgtk) {
         FILE_IMAGE *file_image = calloc(1, sizeof(FILE_IMAGE));
+        if (!file_image) {
+            LOG_ERR("Native", "Could not allocate memory.");
+            return false;
+        }
+
         file_image->name       = name;
         file_image->data       = image;
         file_image->data_size  = image_size;

--- a/src/xlib/gtk.c
+++ b/src/xlib/gtk.c
@@ -348,7 +348,7 @@ static void ugtk_save_chatlog_thread(void *args) {
     utoxGTK_open = false;
 }
 
-void ugtk_save_image_png_thread(void *args) {
+static void ugtk_save_image_png_thread(void *args) {
     FILE_IMAGE *image = args;
 
     char name[TOX_MAX_NAME_LENGTH + sizeof ".png"] = { 0 };
@@ -430,7 +430,6 @@ void ugtk_file_save_image_png(FILE_IMAGE *image) {
         return;
     }
     utoxGTK_open = true;
-    LOG_ERR("Native", "no thread name=%s", image->name);
     thread(ugtk_save_image_png_thread, image);
 }
 

--- a/src/xlib/gtk.h
+++ b/src/xlib/gtk.h
@@ -8,9 +8,9 @@ typedef struct msg_header MSG_HEADER;
 typedef struct file_transfer FILE_TRANSFER;
 
 typedef struct {
-    char    *name;
+    char *name;
     uint8_t *data;
-    int      data_size;
+    int data_size;
 } FILE_IMAGE;
 
 void ugtk_openfilesend(void);
@@ -23,6 +23,11 @@ void ugtk_file_save_inline(MSG_HEADER *msg);
 
 void ugtk_save_chatlog(uint32_t friend_number);
 
+/**
+ * @brief Save passed image to selected file.
+ *
+ * Takes ownership of file_image.
+ */
 void ugtk_file_save_image_png(FILE_IMAGE *file_image);
 
 void *ugtk_load(void);

--- a/src/xlib/gtk.h
+++ b/src/xlib/gtk.h
@@ -5,8 +5,13 @@
 
 typedef struct file_transfer FILE_TRANSFER;
 typedef struct msg_header MSG_HEADER;
-
 typedef struct file_transfer FILE_TRANSFER;
+
+typedef struct {
+    char    *name;
+    uint8_t *data;
+    int      data_size;
+} FILE_IMAGE;
 
 void ugtk_openfilesend(void);
 
@@ -17,6 +22,8 @@ void ugtk_native_select_dir_ft(uint32_t fid, FILE_TRANSFER *file);
 void ugtk_file_save_inline(MSG_HEADER *msg);
 
 void ugtk_save_chatlog(uint32_t friend_number);
+
+void ugtk_file_save_image_png(FILE_IMAGE *file_image);
 
 void *ugtk_load(void);
 


### PR DESCRIPTION
Closes #1055.

QR code is generated from Tox ID (as Tox URI) on init and stored in `self` struct.
On the settings page added button to show/hide QR code.

![pic](https://puu.sh/y26h3/37f87e5931.png)

There's a context menu on QR code itself with one item: save to file (implemented for all platforms except Android).

QR generation is made by [QR-Code-generator](https://github.com/nayuki/QR-Code-generator). It's lightweight fast str8c lib.
I've added it as submodule to `third-party` folder (where we should move all other libs such as `stb` and `minini`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1097)
<!-- Reviewable:end -->
