### PR TITLE
Allow to override saved theme from cmd args even when it's default

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -112,7 +112,7 @@ SETTINGS settings = {
     .verbose = LOG_LVL_ERROR,
     .debug_file = NULL,
 
-    // .theme                       // included here to match the full struct
+    .theme                = UINT32_MAX,
     // OS interface settings
     .window_x             = 0,
     .window_y             = 0,
@@ -508,9 +508,7 @@ UTOX_SAVE *config_load(void) {
     // TODO: Don't clobber (and start saving) commandline flags.
 
     // Allow users to override theme on the cmdline.
-    // 0 is the default theme.
-    // TODO: `utox -t default` is still broken.
-    if (settings.theme == 0) {
+    if (settings.theme == UINT32_MAX) {
         settings.theme = save->theme;
     }
 


### PR DESCRIPTION
Fix broken `utox -t default`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1101)
<!-- Reviewable:end -->
