### PR TITLE
Fix bug that would put uToxGTK in a bad state

### DIFF
--- a/src/xlib/gtk.c
+++ b/src/xlib/gtk.c
@@ -321,6 +321,7 @@ static void ugtk_save_chatlog_thread(void *args) {
     FRIEND *f = get_friend(friend_number);
     if (!f) {
         LOG_ERR("GTK", "Could not get friend with number: %u", friend_number);
+        utoxGTK_open = false;
         return;
     }
 
@@ -352,13 +353,14 @@ void ugtk_openfilesend(void) {
     if (utoxGTK_open) {
         return;
     }
-    utoxGTK_open = true;
+
     FRIEND *f = flist_get_friend();
     if (!f) {
         LOG_ERR("GTK", "Unable to get friend from flist.");
         return;
     }
 
+    utoxGTK_open = true;
     uint32_t number = f->number;
     thread(ugtk_opensendthread, (void*)(size_t)number);
 }
@@ -375,7 +377,7 @@ void ugtk_native_select_dir_ft(uint32_t UNUSED(fid), FILE_TRANSFER *file) {
     if (utoxGTK_open) {
         return;
     }
-    utoxGTK_open   = true;
+    utoxGTK_open = true;
     thread(ugtk_savethread, file);
 }
 


### PR DESCRIPTION
If uTox starts reporting a friend as offline at the wrong time the GTK
code will never set utoxGTK_open back to false and always instantly return
when called after this point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1113)
<!-- Reviewable:end -->
