### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - gcc-5
+            - gcc
             - mingw-w64
             - gcc-mingw-w64
             - mingw-w64-common
@@ -63,7 +63,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - gcc-5
+            - gcc
             - mingw-w64
             - gcc-mingw-w64
             - mingw-w64-common


### PR DESCRIPTION
The new image on Travis apparently doesn't have gcc-5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1154)
<!-- Reviewable:end -->
