### PR TITLE
Appveyor (Windows CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# μTox [![Build Status](https://travis-ci.org/uTox/uTox.svg?branch=develop)](https://travis-ci.org/uTox/uTox) [![Coverage](https://img.shields.io/badge/coverage-0.01%25-red.svg)](#) [![IRC](https://img.shields.io/badge/freenode-%23utox-brightgreen.svg)](https://webchat.freenode.net/?channels=#utox)
+# μTox [![Build Status](https://travis-ci.org/uTox/uTox.svg?branch=develop)](https://travis-ci.org/uTox/uTox) [![Build status](https://ci.appveyor.com/api/projects/status/bswtxxs4e93rdw2u/branch/appveyor-ci?svg=true)](https://ci.appveyor.com/project/redmanmale/utox)  [![Coverage](https://img.shields.io/badge/coverage-0.01%25-red.svg)](#) [![IRC](https://img.shields.io/badge/freenode-%23utox-brightgreen.svg)](https://webchat.freenode.net/?channels=#utox)
 
 The lightweight [Tox](https://github.com/TokTok/toxcore) client.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+version: 'utox-cygwin-{build}'
+clone_depth: 1
+environment:
+    CYG_CACHE: C:\cygwin64\var\cache\setup
+cache:
+    - '%CYG_CACHE%'
+install:
+    - git submodule init && git submodule update && mkdir libs\windows-x64 && cd libs\windows-x64
+
+    # install deps
+    - C:\cygwin64\setup-x86_64.exe -qgnNdO -l %CYG_CACHE% -R c:\cygwin64 -s http://cygwin.mirror.constant.com -P cmake,make,mingw64-x86_64-gcc-core
+
+    # toxcore
+    - if not exist %CYG_CACHE%\toxcore.zip curl -L https://build.tox.chat/view/libtoxcore/job/libtoxcore-toktok_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libtoxcore-toktok_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\toxcore.zip
+    - unzip -o %CYG_CACHE%\toxcore.zip
+
+    # openal
+    - if not exist %CYG_CACHE%\openal.zip curl -L  https://build.tox.chat/view/libopenal/job/libopenal_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libopenal_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\openal.zip
+    - unzip -o %CYG_CACHE%\openal.zip
+
+    # sodium
+    - if not exist %CYG_CACHE%\sodium.zip curl -L https://build.tox.chat/view/libsodium/job/libsodium_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libsodium_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\sodium.zip
+    - unzip -o %CYG_CACHE%\sodium.zip
+
+    # vpx
+    - if not exist %CYG_CACHE%\vpx.zip curl -L https://build.tox.chat/view/libvpx/job/libvpx_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libvpx_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\vpx.zip
+    - unzip -o %CYG_CACHE%\vpx.zip
+
+    # opus
+    - if not exist %CYG_CACHE%\opus.zip curl -L https://build.tox.chat/view/libopus/job/libopus_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libopus_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\opus.zip
+    - unzip -o %CYG_CACHE%\opus.zip
+
+    # filter_audio
+    - if not exist %CYG_CACHE%\filter_audio.zip curl -L https://build.tox.chat/view/libfilteraudio/job/libfilteraudio_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libfilteraudio.zip -o %CYG_CACHE%\filter_audio.zip
+    - unzip -o %CYG_CACHE%\filter_audio.zip
+
+build_script:
+    - C:\Cygwin64\bin\bash -e -l -c "cd C:/projects/utox ; mkdir build ; cd build ; cmake -DCMAKE_TOOLCHAIN_FILE=C:/projects/utox/cmake/toolchain-win64.cmake -DTOXCORE_STATIC=ON .. ; make"
+    - copy C:\projects\utox\build\utox.exe C:\projects\utox\uTox.exe
+
+artifacts:
+  - name: uTox.exe
+    path: uTox.exe
+
+# branches:
+  # only:
+  # - master
+  # - develop

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
     - unzip -o %CYG_CACHE%\filter_audio.zip
 
 build_script:
-    - C:\Cygwin64\bin\bash -e -l -c "cd C:/projects/utox ; mkdir build ; cd build ; cmake -DCMAKE_TOOLCHAIN_FILE=C:/projects/utox/cmake/toolchain-win64.cmake -DTOXCORE_STATIC=ON .. ; make"
+    - C:\Cygwin64\bin\bash -e -l -c "cd C:/projects/utox ; extra/common/set-nightly-build-warning.sh ; mkdir build ; cd build ; cmake -DCMAKE_TOOLCHAIN_FILE=C:/projects/utox/cmake/toolchain-win64.cmake -DTOXCORE_STATIC=ON .. ; make"
     - copy C:\projects\utox\build\utox.exe C:\projects\utox\uTox.exe
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,27 +11,27 @@ install:
     - C:\cygwin64\setup-x86_64.exe -qgnNdO -l %CYG_CACHE% -R c:\cygwin64 -s http://cygwin.mirror.constant.com -P cmake,make,mingw64-x86_64-gcc-core
 
     # toxcore
-    - if not exist %CYG_CACHE%\toxcore.zip curl -L https://build.tox.chat/view/libtoxcore/job/libtoxcore-toktok_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libtoxcore-toktok_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\toxcore.zip
+    - curl -L https://build.tox.chat/view/libtoxcore/job/libtoxcore-toktok_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libtoxcore-toktok_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\toxcore.zip
     - unzip -o %CYG_CACHE%\toxcore.zip
 
     # openal
-    - if not exist %CYG_CACHE%\openal.zip curl -L  https://build.tox.chat/view/libopenal/job/libopenal_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libopenal_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\openal.zip
+    - curl -L  https://build.tox.chat/view/libopenal/job/libopenal_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libopenal_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\openal.zip
     - unzip -o %CYG_CACHE%\openal.zip
 
     # sodium
-    - if not exist %CYG_CACHE%\sodium.zip curl -L https://build.tox.chat/view/libsodium/job/libsodium_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libsodium_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\sodium.zip
+    - curl -L https://build.tox.chat/view/libsodium/job/libsodium_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libsodium_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\sodium.zip
     - unzip -o %CYG_CACHE%\sodium.zip
 
     # vpx
-    - if not exist %CYG_CACHE%\vpx.zip curl -L https://build.tox.chat/view/libvpx/job/libvpx_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libvpx_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\vpx.zip
+    - curl -L https://build.tox.chat/view/libvpx/job/libvpx_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libvpx_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\vpx.zip
     - unzip -o %CYG_CACHE%\vpx.zip
 
     # opus
-    - if not exist %CYG_CACHE%\opus.zip curl -L https://build.tox.chat/view/libopus/job/libopus_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libopus_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\opus.zip
+    - curl -L https://build.tox.chat/view/libopus/job/libopus_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libopus_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\opus.zip
     - unzip -o %CYG_CACHE%\opus.zip
 
     # filter_audio
-    - if not exist %CYG_CACHE%\filter_audio.zip curl -L https://build.tox.chat/view/libfilteraudio/job/libfilteraudio_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libfilteraudio.zip -o %CYG_CACHE%\filter_audio.zip
+    - curl -L https://build.tox.chat/view/libfilteraudio/job/libfilteraudio_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libfilteraudio.zip -o %CYG_CACHE%\filter_audio.zip
     - unzip -o %CYG_CACHE%\filter_audio.zip
 
 build_script:

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -5,6 +5,17 @@ probably help you out.
 
 If you're looking for it to "just work" you're going to want [these instructions](INSTALL.md).
 
+## Instructions
+
+- [Unix Like](#unix-like)
+  * [Linux](#linux)
+  * [Ubuntu](#ubuntu)
+  * [OpenBSD](#openbsd)
+  * [FreeBSD](#freebsd)
+- [Windows](#windows)
+- [macOS](#macos)
+- [Android](#android)
+
 ## Unix Like
 
 ### Linux
@@ -40,8 +51,10 @@ For the build to pass you need to install the following from sources: [filteraud
 
 For base emoji ids support you need: [base_emoji](https://github.com/irungentoo/base_emoji)
 
-## Ubuntu
-### Tested on Ubuntu 15.10
+### Ubuntu
+
+Tested on Ubuntu 16.04
+
 ```bash
 sudo apt-get install build-essential libtool autotools-dev automake checkinstall check git yasm libopus-dev libvpx-dev pkg-config libfontconfig1-dev libdbus-1-dev libv4l-dev libxrender-dev libopenal-dev libxext-dev cmake
 
@@ -83,7 +96,7 @@ Have fun!
 
 If you're looking for a good IDE, Netbeans is very easy to set up for uTox. In fact, you can just create a new project from the existing sources and everything should work fine.
 
-## OpenBSD
+### OpenBSD
 
 uTox will compile on OpenBSD although not everything works.
 
@@ -116,7 +129,7 @@ make
 sudo make install
 ```
 
-## FreeBSD
+### FreeBSD
 
 Install the dependencies:
 

--- a/extra/common/set-nightly-build-warning.sh
+++ b/extra/common/set-nightly-build-warning.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+WARNING='NIGHTLY BUILD FOR TESTING PURPOSES ONLY'
+LANG_REGEX='msgid\(UTOX_SETTINGS\)'
+
+replace_in_branding() {
+    sed -i "s/#define TITLE \"uTox/& ${WARNING}/" $1
+}
+
+replace_in_lang() {
+    need_replace=0
+    while read str; do
+        if [ $need_replace -eq 1 ]; then
+            # everything BEFORE second double quote
+            start=$(echo $str | awk -F\" '{printf "%s\"%s", $1, $2}')
+
+            # everything AFTER second double quote
+            end=$(echo $str | awk -F\" -vOFS='\"' '{ $1 = $2 = ""; print }' | cut -c 2- )
+
+            # insert warning after translation string
+            sed -i "s|${str}|${start} ${WARNING}${end}|" $1
+        fi
+        if [[ $str =~ $LANG_REGEX ]]; then
+            need_replace=1
+        else
+            need_replace=0
+        fi
+    done < $1
+}
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+# replace in lang files
+for lang in $SCRIPTPATH/../../langs/*; do
+    replace_in_lang $lang
+done
+
+# replace in branding files
+replace_in_branding $(realpath $SCRIPTPATH/../../src/branding.h)
+replace_in_branding $(realpath $SCRIPTPATH/../../src/branding.h.in)


### PR DESCRIPTION
Set up Appveyor CI integration: build uTox on Windows (via Cygwin) and allow to download a result artefact for each build ([link](https://ci.appveyor.com/project/redmanmale/utox/build/artifacts)).

It's pointed to my fork and project at Appveyor, so someone with owner access (@GrayHatter probably) needs to login with his GitHub profile to Appveyor and create uTox organization project (with url like https://ci.appveyor.com/project/utox/utox).
After that you need to update readme badge link with this new projectId.

Also in `appveyor.yml` you need you to uncomment last few strings to build only develop/master/PR.
I've disabled it for now to show that all is working.

And we probably could add Appveyor build success as GitHub PR check.

And I updated build instructions a bit.

I wrote a script to put a BIG FAT WARNING into this artefacts and I hope it's verbose enough.
![pic](https://puu.sh/zTjA5/823cd220b1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1193)
<!-- Reviewable:end -->
