### PR TITLE
Don't pass -1 to _fdopen

### DIFF
--- a/src/windows/filesys.c
+++ b/src/windows/filesys.c
@@ -62,6 +62,9 @@ static FILE* get_file(wchar_t path[UTOX_FILE_NAME_LENGTH], UTOX_FILE_OPTS opts) 
         rw |= GENERIC_WRITE;
         mode[0] = 'w';
         create = CREATE_ALWAYS;
+    } else {
+        LOG_ERR("WinFilesys", "get_file called with invalid opts");
+        return NULL;
     }
 
     mode[1] = 'b';
@@ -72,7 +75,12 @@ static FILE* get_file(wchar_t path[UTOX_FILE_NAME_LENGTH], UTOX_FILE_OPTS opts) 
     HANDLE WINAPI winFile = CreateFileW(path, rw, FILE_SHARE_READ, NULL,
                                         create, FILE_ATTRIBUTE_NORMAL, NULL);
 
-    return _fdopen(_open_osfhandle((intptr_t)winFile, 0), mode);
+    const int handle = _open_osfhandle((intptr_t)winFile, 0);
+    if (handle == -1) {
+        return NULL;
+    }
+
+    return _fdopen(handle, mode);
 }
 
 FILE *native_get_file_simple(const char *path, UTOX_FILE_OPTS opts) {


### PR DESCRIPTION
This fixes Windows uTox getting spammed with `Invalid parameter passed to C runtime function`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1212)
<!-- Reviewable:end -->
