### PR TITLE
Fix selection bug

### DIFF
--- a/src/messages.c
+++ b/src/messages.c
@@ -1503,15 +1503,17 @@ bool messages_dclick(PANEL *panel, bool triclick) {
             case MSG_TYPE_ACTION_TEXT: {
                 m->sel_start_msg = m->sel_end_msg = m->cursor_over_msg;
 
-                const char c = triclick ? '\n' : ' ';
-
                 uint16_t i = m->cursor_over_position;
-                while (i != 0 && msg->via.txt.msg[i - 1] != c) {
+                while (i != 0 && msg->via.txt.msg[i - 1] != '\n'
+                       /*  If it's a dclick, also set ' ' as boundary, else do nothing. */
+                       && (!triclick ? (msg->via.txt.msg[i - 1] != ' ') : 1)) {
                     i -= utf8_unlen(msg->via.txt.msg + i);
                 }
                 m->sel_start_position = i;
                 i = m->cursor_over_position;
-                while (i != msg->via.txt.length && msg->via.txt.msg[i] != c) {
+                while (i != msg->via.txt.length && msg->via.txt.msg[i] != '\n'
+                       /*  If it's a dclick, also set ' ' as boundary, else do nothing. */
+                       && (!triclick ? (msg->via.txt.msg[i] != ' ') : 1)) {
                     i += utf8_len(msg->via.txt.msg + i);
                 }
                 m->sel_end_position = i;

--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -232,15 +232,17 @@ bool edit_dclick(EDIT *edit, bool triclick) {
         edit->mouseover_char = edit->length;
     }
 
-    char c = triclick ? '\n' : ' ';
-
     uint16_t i = edit->mouseover_char;
-    while (i != 0 && edit->data[i - 1] != c) {
+    while (i != 0 && edit->data[i - 1] != '\n'
+           /*  If it's a dclick, also set ' ' as boundary, else do nothing. */
+           && (!triclick ? (edit->data[i - 1] != ' ') : 1)) {
         i -= utf8_unlen(edit->data + i);
     }
     edit_sel.start = edit_sel.p1 = i;
     i                            = edit->mouseover_char;
-    while (i != edit->length && edit->data[i] != c) {
+    while (i != edit->length && edit->data[i] != '\n'
+           /*  If it's a dclick, also set ' ' as boundary, else do nothing. */
+           && (!triclick ? (edit->data[i] != ' ') : 1)) {
         i += utf8_len(edit->data + i);
     }
     edit_sel.p2     = i;


### PR DESCRIPTION
Now, when the user doubleclicks the first or last word in a line of a multiline message, the selection doesn't leak into the neighbouring line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1262)
<!-- Reviewable:end -->
