### PR TITLE
Fix minor issue with HOME and END keys

### DIFF
--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -612,7 +612,7 @@ void edit_char(uint32_t ch, bool control, uint8_t flags) {
             case KEY_HOME: {
                 uint16_t p = edit_sel.p2;
 
-                if (p == 0) {
+                if (p == 0 && !edit_sel.length) {
                     break;
                 }
 
@@ -628,9 +628,6 @@ void edit_char(uint32_t ch, bool control, uint8_t flags) {
                     edit_sel.p2 = p;
                     updatesel();
                 } else {
-                    if (edit_sel.length) {
-                        p = edit_sel.start;
-                    }
                     edit_sel.p1     = p;
                     edit_sel.p2     = p;
                     edit_sel.start  = p;
@@ -642,7 +639,7 @@ void edit_char(uint32_t ch, bool control, uint8_t flags) {
             case KEY_END: {
                 uint16_t p = edit_sel.p2;
 
-                if (p == edit->length) {
+                if (p == edit->length && !edit_sel.length) {
                     break;
                 }
 
@@ -658,9 +655,6 @@ void edit_char(uint32_t ch, bool control, uint8_t flags) {
                     edit_sel.p2 = p;
                     updatesel();
                 } else {
-                    if (edit_sel.length) {
-                        p = edit_sel.start + edit_sel.length;
-                    }
                     edit_sel.p1     = p;
                     edit_sel.p2     = p;
                     edit_sel.start  = p;


### PR DESCRIPTION
This fixes a non-standard behaviour of the HOME and END keys.
Now, when HOME/END is pressed while there is also a selection, the cursor goes to the beginning or end of line, instead of only to the beginning or end of the selection. Going to the beginning/end of the selection is correct behaviour for LEFT and RIGHT, but not for HOME/END.

This also fixes a premature break bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1267)
<!-- Reviewable:end -->
