### PR TITLE
Fixing a nasty reallocation bug

### DIFF
--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -357,6 +357,10 @@ void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
     if (!history) {
         LOG_FATAL_ERR(EXIT_MALLOC, "UI Edit", "Unable to realloc for edit history, this should never happen!");
     }
+    /* Note: if we access edit->history after reallocing it, we're using
+       potentially freed memory.
+    */
+    edit->history = history;
 
     new = calloc(1, sizeof(EDIT_CHANGE) + length);
     if (!new) {
@@ -376,7 +380,6 @@ void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
     }
 
     history[edit->history_cur] = new;
-    edit->history              = history;
 
     edit->history_cur++;
     edit->history_length = edit->history_cur;


### PR DESCRIPTION
uTox was crashing my client randomly, growing increasingly unstable when deleting text. Problem seems to be a memory access issue in edit_do, where something like this occurs:

history = realloc(edit->history, ...);
dolotsofstuffwith(edit->history, *edit->history, edit->history[++i]);
edit->history = history;

No more crashes while typing/deleting so far, for me at least.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1284)
<!-- Reviewable:end -->
