### PR TITLE
Make push-to-talk work at every X11 platform.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ elseif(UNIX)
         set(NETBSD TRUE)
     elseif(CMAKE_SYSTEM_NAME MATCHES "kFreeBSD.*|FreeBSD")
         set(FREEBSD TRUE)
+    elseif(CMAKE_SYSTEM_NAME MATCHES "kDragonFly.*|DragonFly")
+        set(DRAGONFLY TRUE)
     endif()
 endif()
 
@@ -308,6 +310,10 @@ elseif(APPLE)
 elseif(UNIX)
     find_package(X11 REQUIRED)
     include_directories(${X11_INCLUDE_DIR})
+
+    if(DRAGONFLY)
+        include_directories("/usr/include/compat")
+    endif()
 
     add_subdirectory(src/xlib)
 

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -92,14 +92,16 @@ void init_ptt(void) {
 
 
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__DragonFly__)
 #include <linux/input.h>
-#elif defined(__DragonFly__) || defined(__FreeBSD__)
-#include <dev/misc/evdev/input.h>
+#define HAVE_EVDEV
+#elif defined(__FreeBSD__)
+#include <dev/evdev/input.h>
+#define HAVE_EVDEV
 #endif
 
-#if defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__)
 static bool linux_check_ptt(void) {
+#ifdef HAVE_EVDEV
     /* First, we try for direct access to the keyboard. */
     int ptt_key = KEY_LEFTCTRL; // TODO allow user to change this...
     if (ptt_keyboard_handle) {
@@ -122,6 +124,9 @@ static bool linux_check_ptt(void) {
     /* Okay nope, lets' fallback to xinput... *pouts*
      * Fall back to Querying the X for the current keymap. */
     ptt_key       = XKeysymToKeycode(display, XK_Control_L);
+#else
+    int ptt_key   = XKeysymToKeycode(display, XK_Control_L);
+#endif
     char keys[32] = { 0 };
     /* We need our own connection, so that we don't block the main display... No idea why... */
     if (ptt_display) {
@@ -139,11 +144,6 @@ static bool linux_check_ptt(void) {
                 "keyboard.\nDisable push to talk to suppress this message.\n");
     return false;
 }
-#else
-static bool bsd_check_ptt(void) {
-    return false;
-}
-#endif
 
 bool check_ptt_key(void) {
     if (!settings.push_to_talk) {
@@ -151,11 +151,7 @@ bool check_ptt_key(void) {
         return true; /* If push to talk is disabled, return true. */
     }
 
-#if defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__)
-    return linux_check_ptt();
-#else
-    return bsd_check_ptt();
-#endif
+    return check_ptt();
 }
 
 void exit_ptt(void) {


### PR DESCRIPTION
DragonFly BSD changed location for evdev input.h file, FreeBSD has different location from the beginning. Note that DragonFly BSD is compiled without evdev support by default, but it still has that header.