### PR TITLE
Use correct evdev header on FreeBSD

### DIFF
--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -93,10 +93,8 @@ void init_ptt(void) {
 
 
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__)
 #include <linux/input.h>
-#elif defined(__DragonFly__) || defined(__FreeBSD__)
-#include <dev/misc/evdev/input.h>
 #endif
 
 #if defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__)


### PR DESCRIPTION
There is no `dev/misc/evdev/input.h` on FreeBSD.  There is a
`dev/evdev/input.h`.  However in general it is recommended to use
`linux/input.h` from the `evdev-proto` package instead since can
be updated more quickly.  Switch to it to not cause future problems.

AFAICT DragonFlyBSD also does not have a `dev/misc/evdev/input.h`.
DPorts has an `evdev-proto` package too, so it should be fine to use
`linux/input.h` there as well.