### PR TITLE
Handle Home & End key in messages panel

### DIFF
--- a/src/messages.c
+++ b/src/messages.c
@@ -1821,6 +1821,16 @@ bool messages_char(uint32_t ch) {
 
             return true;
         }
+
+        case KEY_HOME: {
+            m->panel.content_scroll->d = 0.0;
+            return true;
+        }
+
+        case KEY_END: {
+            m->panel.content_scroll->d = 1.0;
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
Home now scrolls to top    of message log
End  now scrolls to bottom of message log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1387)
<!-- Reviewable:end -->
