### PR TITLE
Unbreak build with OpenAL 1.20.0

### DIFF
--- a/src/av/audio.h
+++ b/src/av/audio.h
@@ -5,7 +5,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-typedef struct ALCdevice_struct ALCdevice;
+#ifdef __APPLE__
+#include <OpenAL/alc.h>
+#else
+#include <AL/alc.h>
+#endif
 
 extern bool utox_audio_thread_init;
 


### PR DESCRIPTION
```
In file included from /home/tobias/src/github.com/uTox/uTox/src/av/audio.c:33:
/usr/local/include/AL/alc.h:34:26: error: typedef redefinition with different types
      ('struct ALCdevice' vs 'struct ALCdevice_struct')
typedef struct ALCdevice ALCdevice;
                         ^
/home/tobias/src/github.com/uTox/uTox/src/av/audio.h:8:33: note: previous definition is here
typedef struct ALCdevice_struct ALCdevice;
                                ^
1 error generated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1401)
<!-- Reviewable:end -->
