### PR TITLE
Don't pass 2 of every flags in CFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,6 @@ function(add_cflag flag)
     endif()
 endfunction()
 
-# Grab environment CFLAGS.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} $ENV{CFLAGS}")
-
 # Warn on non-ISO C.
 #add_cflag("-pedantic") # throws a lot of warning, quite sure we do not want this at current state.
 ## Add all warning flags we can.


### PR DESCRIPTION
The variable CMAKE_C_FLAGS is initialised from CFLAGS by CMake, see:
https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1426)
<!-- Reviewable:end -->
