### PR TITLE
Update Cygwin packages for Windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
     - git submodule init && git submodule update && mkdir libs\windows-x64 && cd libs\windows-x64
 
     # install deps
-    - C:\cygwin64\setup-x86_64.exe -qgnNdO -l %CYG_CACHE% -R c:\cygwin64 -s http://cygwin.mirror.constant.com -P cmake,make,mingw64-x86_64-gcc-core
+    - C:\cygwin64\setup-x86_64.exe -qgnNdO -l %CYG_CACHE% -R c:\cygwin64 -s http://cygwin.mirror.constant.com -P cmake,make,mingw64-x86_64-gcc-core,gcc-g++
 
     # toxcore
     - curl -L https://build.tox.chat/view/libtoxcore/job/libtoxcore-toktok_build_windows_x86-64_static_release/lastSuccessfulBuild/artifact/libtoxcore-toktok_build_windows_x86-64_static_release.zip -o %CYG_CACHE%\toxcore.zip

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -198,7 +198,7 @@ Before compiling please make sure you have all of the [dependencies](DEPENDENCIE
   - mingw64-i686-gcc-core (x86) / mingw64-x86_64-gcc-core (x64)
   - make
   - cmake
-  - gdb
+  - gcc-g++
 
 All following commands should be executed in Cygwin Terminal.
 


### PR DESCRIPTION
to be able to build dependencies with Cmake after #1445.

The Appveyor build haven't fail because it has already pre-installed this package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1449)
<!-- Reviewable:end -->
