### PR TITLE
Refactoring save and load settings

### DIFF
--- a/src/android/main.c
+++ b/src/android/main.c
@@ -468,9 +468,6 @@ void force_redraw(void) {
 void update_tray(void) { /* Unsupported on android */
 }
 
-void config_osdefaults(UTOX_SAVE *r) { /* Unsupported on android */
-}
-
 void utox_android_redraw_window(void) {
     if (!_redraw) {
         return;

--- a/src/av/audio.c
+++ b/src/av/audio.c
@@ -703,7 +703,7 @@ void utox_audio_thread(void *args) {
                     break;
                 }
                 case UTOXAUDIO_PLAY_RINGTONE: {
-                    if (settings.ringtone_enabled && self.status != USER_STATUS_DO_NOT_DISTURB) {
+                    if (settings.audible_notifications_enabled && self.status != USER_STATUS_DO_NOT_DISTURB) {
                         LOG_INFO("uTox Audio", "Going to start ringtone!" );
 
                         audio_out_device_open();
@@ -727,7 +727,7 @@ void utox_audio_thread(void *args) {
                     break;
                 }
                 case UTOXAUDIO_PLAY_NOTIFICATION: {
-                    if (settings.ringtone_enabled && self.status == USER_STATUS_AVAILABLE) {
+                    if (settings.audible_notifications_enabled && self.status == USER_STATUS_AVAILABLE) {
                         LOG_INFO("uTox Audio", "Going to start notification tone!" );
 
                         if (close_device_time <= time(NULL)) {
@@ -783,7 +783,7 @@ void utox_audio_thread(void *args) {
             }
         }
 
-        settings.audiofilter_enabled = filter_audio_check();
+        settings.audio_filtering_enabled = filter_audio_check();
 
         bool sleep = true;
 
@@ -811,7 +811,7 @@ void utox_audio_thread(void *args) {
 
             #ifdef AUDIO_FILTERING
             #ifdef ALC_LOOPBACK_CAPTURE_SAMPLES
-            if (f_a && settings.audiofilter_enabled) {
+            if (f_a && settings.audio_filtering_enabled) {
                 alcGetIntegerv(audio_out_device, ALC_LOOPBACK_CAPTURE_SAMPLES, sizeof(samples), &samples);
                 if (samples >= perframe) {
                     int16_t buffer[perframe];

--- a/src/av/filter_audio.c
+++ b/src/av/filter_audio.c
@@ -14,20 +14,20 @@ Filter_Audio *f_a = NULL;
 
 bool filter_audio_check(void) {
 #ifdef AUDIO_FILTERING
-    if (!f_a && settings.audiofilter_enabled) {
+    if (!f_a && settings.audio_filtering_enabled) {
         f_a = new_filter_audio(UTOX_DEFAULT_SAMPLE_RATE_A);
         if (!f_a) {
             LOG_INFO("Filter Audio", "filter audio failed" );
             return false;
         }
         LOG_INFO("Filter Audio", "filter audio on" );
-    } else if (f_a && !settings.audiofilter_enabled) {
+    } else if (f_a && !settings.audio_filtering_enabled) {
         kill_filter_audio(f_a);
         f_a = NULL;
         LOG_INFO("Filter Audio", "filter audio off" );
         return false;
     }
-    return settings.audiofilter_enabled;
+    return settings.audio_filtering_enabled;
 #else
     return false;
 #endif

--- a/src/branding.h
+++ b/src/branding.h
@@ -22,4 +22,3 @@
 // Defaults
 #define DEFAULT_NAME "uTox User"
 #define DEFAULT_STATUS "Toxing on uTox, from the future!"
-#define DEFAULT_SCALE 11

--- a/src/branding.h.in
+++ b/src/branding.h.in
@@ -22,4 +22,3 @@
 // Defaults
 #define DEFAULT_NAME "uTox User"
 #define DEFAULT_STATUS "Toxing on uTox, from the future!"
-#define DEFAULT_SCALE 11

--- a/src/cocoa/main.m
+++ b/src/cocoa/main.m
@@ -405,16 +405,14 @@ void launch_at_startup(bool should) {
     postmessage_utoxav(UTOXAV_KILL, 0, 0, NULL);
     postmessage_toxcore(TOX_KILL, 0, 0, NULL);
 
-    UTOX_SAVE d = {
-        // from bottom of screen
-        // TODO: translate to xy from top
-        .window_x      = self.utox_window.frame.origin.x,
-        .window_y      = self.utox_window.frame.origin.y,
-        .window_width  = self.utox_window.frame.size.width,
-        .window_height = self.utox_window.frame.size.height,
-    };
+    // from bottom of screen
+    // TODO: translate to xy from top
+    settings.window_x      = self.utox_window.frame.origin.x;
+    settings.window_y      = self.utox_window.frame.origin.y;
+    settings.window_width  = self.utox_window.frame.size.width;
+    settings.window_height = self.utox_window.frame.size.height;
 
-    config_save(&d);
+    config_save();
 
     [NSEvent removeMonitor:global_event_listener];
     [NSEvent removeMonitor:local_event_listener];
@@ -423,7 +421,6 @@ void launch_at_startup(bool should) {
     while (tox_thread_init) {
         yieldcpu(1);
     }
-
 }
 
 - (void)soilWindowContents {

--- a/src/cocoa/main.m
+++ b/src/cocoa/main.m
@@ -35,9 +35,6 @@ struct thread_call {
     void *argp;
 };
 
-#define DEFAULT_WIDTH (382 * DEFAULT_SCALE)
-#define DEFAULT_HEIGHT (320 * DEFAULT_SCALE)
-
 int NATIVE_IMAGE_IS_VALID(NATIVE_IMAGE *img) {
     return img != NULL && img->image != nil;
 }
@@ -138,13 +135,6 @@ uint64_t get_time(void) {
     ts.tv_nsec = machtime.tv_nsec;
 
     return ((uint64_t)ts.tv_sec * (1000 * 1000 * 1000)) + (uint64_t)ts.tv_nsec;
-}
-
-void config_osdefaults(UTOX_SAVE *r) {
-    r->window_x      = 0;
-    r->window_y      = 0;
-    r->window_width  = DEFAULT_WIDTH;
-    r->window_height = DEFAULT_HEIGHT;
 }
 
 bool native_remove_file(const uint8_t *name, size_t length, bool portable_mode) {
@@ -488,9 +478,6 @@ int main(int argc, char const *argv[]) {
 
     utox_init();
 
-    settings.window_width  = DEFAULT_WIDTH;
-    settings.window_height = DEFAULT_HEIGHT;
-
     parse_args(argc, argv,
                &should_launch_at_startup,
                &set_show_window,
@@ -511,7 +498,6 @@ int main(int argc, char const *argv[]) {
     setlocale(LC_ALL, "");
 
     /* set the width/height of the drawing region */
-
     ui_size(settings.window_width, settings.window_height);
 
     /* event loop */

--- a/src/cocoa/main.m
+++ b/src/cocoa/main.m
@@ -402,9 +402,6 @@ void launch_at_startup(bool should) {
 }
 
 - (void)applicationWillTerminate:(NSNotification *)notification {
-    postmessage_utoxav(UTOXAV_KILL, 0, 0, NULL);
-    postmessage_toxcore(TOX_KILL, 0, 0, NULL);
-
     // from bottom of screen
     // TODO: translate to xy from top
     settings.window_x      = self.utox_window.frame.origin.x;
@@ -413,6 +410,9 @@ void launch_at_startup(bool should) {
     settings.window_height = self.utox_window.frame.size.height;
 
     config_save();
+
+    postmessage_utoxav(UTOXAV_KILL, 0, 0, NULL);
+    postmessage_toxcore(TOX_KILL, 0, 0, NULL);
 
     [NSEvent removeMonitor:global_event_listener];
     [NSEvent removeMonitor:local_event_listener];

--- a/src/layout/settings.c
+++ b/src/layout/settings.c
@@ -1250,6 +1250,8 @@ static void switchfxn_proxy(void) {
     edit_proxy_port.data[edit_proxy_port.length] = 0;
     settings.proxy_port = strtol((char *)edit_proxy_port.data, NULL, 0);
 
+    memcpy(settings.proxy_ip, proxy_address, edit_proxy_ip.length);
+
     tox_settingschanged();
 }
 
@@ -1347,6 +1349,7 @@ static void dropdown_video_onselect(uint16_t i, const DROPDOWN *UNUSED(dm)) {
 
 static void dropdown_dpi_onselect(uint16_t i, const DROPDOWN *UNUSED(dm)) {
     ui_rescale(i + 5);
+    settings.scale = ui_scale;
 }
 
 static void dropdown_language_onselect(uint16_t i, const DROPDOWN *UNUSED(dm)) {

--- a/src/layout/settings.c
+++ b/src/layout/settings.c
@@ -273,7 +273,7 @@ static void draw_settings_text_adv(int x, int y, int UNUSED(w), int UNUSED(heigh
     drawstr(x + SCALE(20) + BM_SWITCH_WIDTH, y + SCALE(30),  IPV6);
     drawstr(x + SCALE(20) + BM_SWITCH_WIDTH, y + SCALE(60),  UDP);
     drawstr(x + SCALE(20) + BM_SWITCH_WIDTH, y + SCALE(90),  PROXY);
-    drawstr(x + SCALE(20) + BM_SWITCH_WIDTH, y + SCALE(120), PROXY_FORCE); // TODO draw ONLY when settings.use_proxy = true
+    drawstr(x + SCALE(20) + BM_SWITCH_WIDTH, y + SCALE(120), PROXY_FORCE); // TODO draw ONLY when settings.proxyenable = true
     drawtext(x + SCALE(353), y + SCALE(89), ":", 1); // Little addr port separator
 
     drawstr(x + SCALE(20)+ BM_SWITCH_WIDTH, y + SCALE(150), BLOCK_FRIEND_REQUESTS);
@@ -954,12 +954,12 @@ static void switchfxn_mini_contacts(void) {
 }
 
 static void switchfxn_ipv6(void) {
-    settings.enable_ipv6 = !settings.enable_ipv6;
+    settings.enableipv6 = !settings.enableipv6;
     tox_settingschanged();
 }
 
 static void switchfxn_udp(void) {
-    settings.enable_udp = !settings.enable_udp;
+    settings.disableudp = !settings.disableudp;
     tox_settingschanged();
 }
 
@@ -972,15 +972,15 @@ static void switchfxn_start_in_tray(void) {
 }
 
 static void switchfxn_auto_startup(void) {
-    settings.start_with_system = !settings.start_with_system;
-    launch_at_startup(settings.start_with_system);
+    settings.auto_startup = !settings.auto_startup;
+    launch_at_startup(settings.auto_startup);
 }
 
 static void switchfxn_typing_notes(void) {
-    settings.send_typing_status = !settings.send_typing_status;
+    settings.no_typing_notifications = !settings.no_typing_notifications;
 }
 
-static void switchfxn_audible_notifications(void) { settings.ringtone_enabled = !settings.ringtone_enabled; }
+static void switchfxn_audible_notifications(void) { settings.audible_notifications_enabled = !settings.audible_notifications_enabled; }
 
 static void switchfxn_push_to_talk(void) {
     if (!settings.push_to_talk) {
@@ -990,7 +990,7 @@ static void switchfxn_push_to_talk(void) {
     }
 }
 
-static void switchfxn_audio_filtering(void) { settings.audiofilter_enabled = !settings.audiofilter_enabled; }
+static void switchfxn_audio_filtering(void) { settings.audio_filtering_enabled = !settings.audio_filtering_enabled; }
 
 static void switchfxn_status_notifications(void) { settings.status_notifications = !settings.status_notifications; }
 
@@ -1233,9 +1233,9 @@ UISWITCH switch_block_friend_requests = {
 };
 
 static void switchfxn_proxy(void) {
-    settings.use_proxy   = !settings.use_proxy;
+    settings.proxyenable   = !settings.proxyenable;
 
-    if (settings.use_proxy) {
+    if (settings.proxyenable) {
         switch_proxy_force.panel.disabled = false;
     } else {
         settings.force_proxy              = false;
@@ -1258,7 +1258,7 @@ static void switchfxn_proxy_force(void) {
 
     if (settings.force_proxy) {
         switch_udp.switch_on      = false;
-        settings.enable_udp       = false;
+        settings.disableudp       = true;
         switch_udp.panel.disabled = true;
     } else {
         switch_udp.panel.disabled = false;
@@ -1589,7 +1589,7 @@ static void edit_proxy_ip_port_onlosefocus(EDIT *UNUSED(edit)) {
     proxy_address[edit_proxy_ip.length] = 0;
 
 
-    if (settings.use_proxy) {
+    if (settings.proxyenable) {
         tox_settingschanged();
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -262,13 +262,13 @@ void utox_init(void) {
         settings.debug_file = stdout;
     }
 
-    UTOX_SAVE *save = config_load();
-    free(save);
+    config_load();
 
     /* Called by the native main for every platform after loading utox setting,
      * before showing/drawing any windows. */
     if (settings.utox_last_version != settings.last_version) {
         settings.show_splash = true;
+        settings.utox_last_version = settings.last_version;
     }
 
     // We likely want to start this on every system.

--- a/src/main.c
+++ b/src/main.c
@@ -267,7 +267,7 @@ void utox_init(void) {
 
     /* Called by the native main for every platform after loading utox setting,
      * before showing/drawing any windows. */
-    if (settings.curr_version != settings.last_version) {
+    if (settings.utox_last_version != settings.last_version) {
         settings.show_splash = true;
     }
 

--- a/src/native/os.h
+++ b/src/native/os.h
@@ -20,7 +20,4 @@ void setselection(char *data, uint16_t length);
 // OS X and Windows
 void launch_at_startup(bool should);
 
-// Linux, OS X, and Windows.
-void config_osdefaults(UTOX_SAVE *r);
-
 #endif

--- a/src/native/os.h
+++ b/src/native/os.h
@@ -1,8 +1,6 @@
 #ifndef NATIVE_OS_H
 #define NATIVE_OS_H
 
-typedef struct utox_save UTOX_SAVE;
-
 // OS-specific cleanup function for when edits are defocused. Commit IME state, etc.
 // OS X only.
 void edit_will_deactivate(void);

--- a/src/settings.c
+++ b/src/settings.c
@@ -16,7 +16,8 @@
 #include "native/filesys.h"
 #include "native/keyboard.h"
 
-#include "main.h" // UTOX_VERSION_NUMBER, MAIN_HEIGHT, MAIN_WIDTH, all save things..
+// UTOX_VERSION_NUMBER, MAIN_HEIGHT, MAIN_WIDTH, all save things..
+#include "main.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -25,7 +26,8 @@
 #define MATCH(x, y) (strcasecmp(x, y) == 0)
 #define BOOL_TO_STR(b) b ? "true" : "false"
 #define STR_TO_BOOL(s) (strcasecmp(s, "true") == 0)
-#define NAMEOF(s) strchr((const char *)(#s), '>') == NULL ? #s : (strchr((const char *)(#s), '>') + 1)
+#define NAMEOF(s) strchr((const char *)(#s), '>') == NULL \
+    ? #s : (strchr((const char *)(#s), '>') + 1)
 
 static const char *config_file_name = "utox_save.ini";
 
@@ -60,9 +62,8 @@ SETTINGS settings = {
 
     // Low level settings (network, profile, portable-mode)
     .disableudp     = false,
-    .enableipv6    = true,
-
-    .proxyenable      = false,
+    .enableipv6     = true,
+    .proxyenable    = false,
     .force_proxy    = false,
     .proxy_port     = 0,
 
@@ -72,65 +73,68 @@ SETTINGS settings = {
 
     // User interface settings
     .language               = LANG_EN,
-    .audio_filtering_enabled    = true,
-    .push_to_talk           = false,
-    .audio_preview          = false,
-    .video_preview          = false,
-    .no_typing_notifications     = true,
-    .use_long_time_msg      = true,
-    .accept_inline_images   = true,
+
+    .audio_filtering_enabled = true,
+    .push_to_talk            = false,
+    .audio_preview           = false,
+    .video_preview           = false,
+    .no_typing_notifications = true,
+    .use_long_time_msg       = true,
+    .accept_inline_images    = true,
 
     // UX Settings
-    .logging_enabled        = true,
-    .close_to_tray          = false,
-    .start_in_tray          = false,
-    .auto_startup      = false,
-    .use_mini_flist         = false,
-    .magic_flist_enabled    = false,
-
+    .logging_enabled     = true,
+    .close_to_tray       = false,
+    .start_in_tray       = false,
+    .auto_startup        = false,
+    .use_mini_flist      = false,
+    .magic_flist_enabled = false,
 
     // Notifications / Alerts
-    .audible_notifications_enabled       = true,
-    .status_notifications   = true,
-    .group_notifications    = GNOTIFY_ALWAYS,
+    .audible_notifications_enabled = true,
+    .status_notifications          = true,
+    .group_notifications           = GNOTIFY_ALWAYS,
 
     .audio_device_out = 0,
     .audio_device_in  = 0,
     .video_fps        = DEFAULT_FPS,
 
-    .verbose = LOG_LVL_ERROR,
+    .verbose    = LOG_LVL_ERROR,
     .debug_file = NULL,
 
-    .theme                = UINT32_MAX,
-    // OS interface settings
-    .window_x             = 0,
-    .window_y             = 0,
-    .window_height        = MAIN_HEIGHT,
-    .window_width         = MAIN_WIDTH,
-    .window_baseline      = 0,
+    .theme = UINT32_MAX,
 
-    .window_maximized     = 0,
+    // OS interface settings
+    .window_x         = 0,
+    .window_y         = 0,
+    .window_height    = MAIN_HEIGHT,
+    .window_width     = MAIN_WIDTH,
+    .window_baseline  = 0,
+    .window_maximized = false,
 };
 
-static void write_config_value_int(const char *filename, const char *section, const char *key, const long value) {
+static void write_config_value_int(const char *filename, const char *section,
+                                   const char *key, const long value) {
     if (ini_putl(section, key, value, filename) != 1) {
         LOG_ERR("Settings", "Unable to save config value: %lu.", value);
     }
 }
 
-static void write_config_value_str(const char *filename, const char *section, const char *key, const char *value) {
+static void write_config_value_str(const char *filename, const char *section,
+                                   const char *key, const char *value) {
     if (ini_puts(section, key, value, filename) != 1) {
         LOG_ERR("Settings", "Unable to save config value: %s.", value);
     }
 }
 
-static void write_config_value_bool(const char *filename, const char *section, const char *key, const bool value) {
+static void write_config_value_bool(const char *filename, const char *section,
+                                    const char *key, const bool value) {
     if (ini_puts(section, key, BOOL_TO_STR(value), filename) != 1) {
         LOG_ERR("Settings", "Unable to save config value: %s.", value);
     }
 }
 
-static CONFIG_SECTION get_section(const char* section) {
+static CONFIG_SECTION get_section(const char *section) {
     if (MATCH(config_sections[GENERAL_SECTION], section)) {
         return GENERAL_SECTION;
     } else if (MATCH(config_sections[INTERFACE_SECTION], section)) {
@@ -212,8 +216,9 @@ static void parse_av_section(SETTINGS *config, const char *key,
             return;
         }
 
-        LOG_WARN("Settings", "Fps value (%s) is invalid. It must be integer in range of [1,%u].",
-             value, UINT8_MAX);
+        LOG_WARN("Settings",
+            "Fps value (%s) is invalid. It must be integer in range of [1,%u].",
+            value, UINT8_MAX);
     }
 }
 
@@ -249,10 +254,11 @@ static void parse_advanced_section(SETTINGS *config, const char *key,
     }
 }
 
-static int config_parser(const char* section, const char* key, const char* value, void* config_v) {
+static int config_parser(const char *section, const char *key,
+                         const char *value, void *config_v) {
     SETTINGS *config = (SETTINGS *)config_v;
 
-    switch(get_section(section)) {
+    switch (get_section(section)) {
         case GENERAL_SECTION: {
             parse_general_section(config, key, value);
             break;
@@ -312,48 +318,84 @@ static bool utox_save_config(void) {
     SETTINGS *config = &settings;
 
     // general
-    write_config_value_int(config_path, config_sections[GENERAL_SECTION], NAMEOF(config->save_version), config->save_version);
-    write_config_value_int(config_path, config_sections[GENERAL_SECTION], NAMEOF(config->utox_last_version), config->utox_last_version);
+    write_config_value_int(config_path, config_sections[GENERAL_SECTION],
+        NAMEOF(config->save_version), config->save_version);
+    write_config_value_int(config_path, config_sections[GENERAL_SECTION],
+        NAMEOF(config->utox_last_version), config->utox_last_version);
 
     // interface
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->language), config->language);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->window_x), config->window_x);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->window_y), config->window_y);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->window_width), config->window_width);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->window_height), config->window_height);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->theme), config->theme);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->scale), config->scale);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->logging_enabled), config->logging_enabled);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->close_to_tray), config->close_to_tray);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->start_in_tray), config->start_in_tray);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->auto_startup), config->auto_startup);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->use_mini_flist), config->use_mini_flist);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->filter), config->filter);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->magic_flist_enabled), config->magic_flist_enabled);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION], NAMEOF(config->use_long_time_msg), config->use_long_time_msg);
+    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->language), config->language);
+    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->window_x), config->window_x);
+    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->window_y), config->window_y);
+    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->window_width), config->window_width);
+    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->window_height), config->window_height);
+    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->theme), config->theme);
+    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->scale), config->scale);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->logging_enabled), config->logging_enabled);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->close_to_tray), config->close_to_tray);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->start_in_tray), config->start_in_tray);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->auto_startup), config->auto_startup);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->use_mini_flist), config->use_mini_flist);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->filter), config->filter);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->magic_flist_enabled), config->magic_flist_enabled);
+    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
+        NAMEOF(config->use_long_time_msg), config->use_long_time_msg);
 
     // av
-    write_config_value_bool(config_path, config_sections[AV_SECTION], NAMEOF(config->push_to_talk), config->push_to_talk);
-    write_config_value_bool(config_path, config_sections[AV_SECTION], NAMEOF(config->audio_filtering_enabled), config->audio_filtering_enabled);
-    write_config_value_int(config_path, config_sections[AV_SECTION], NAMEOF(config->audio_device_in), config->audio_device_in);
-    write_config_value_int(config_path, config_sections[AV_SECTION], NAMEOF(config->audio_device_out), config->audio_device_out);
-    write_config_value_int(config_path, config_sections[AV_SECTION], NAMEOF(config->video_fps), config->video_fps);
+    write_config_value_bool(config_path, config_sections[AV_SECTION],
+        NAMEOF(config->push_to_talk), config->push_to_talk);
+    write_config_value_bool(config_path, config_sections[AV_SECTION],
+        NAMEOF(config->audio_filtering_enabled),
+        config->audio_filtering_enabled);
+    write_config_value_int(config_path, config_sections[AV_SECTION],
+        NAMEOF(config->audio_device_in), config->audio_device_in);
+    write_config_value_int(config_path, config_sections[AV_SECTION],
+        NAMEOF(config->audio_device_out), config->audio_device_out);
+    write_config_value_int(config_path, config_sections[AV_SECTION],
+        NAMEOF(config->video_fps), config->video_fps);
     // TODO: video_input_device
 
     // notifications
-    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION], NAMEOF(config->audible_notifications_enabled), config->audible_notifications_enabled);
-    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION], NAMEOF(config->status_notifications), config->status_notifications);
-    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION], NAMEOF(config->no_typing_notifications), config->no_typing_notifications);
-    write_config_value_int(config_path, config_sections[NOTIFICATIONS_SECTION], NAMEOF(config->group_notifications), config->group_notifications);
+    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION],
+        NAMEOF(config->audible_notifications_enabled),
+        config->audible_notifications_enabled);
+    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION],
+        NAMEOF(config->status_notifications), config->status_notifications);
+    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION],
+        NAMEOF(config->no_typing_notifications),
+        config->no_typing_notifications);
+    write_config_value_int(config_path, config_sections[NOTIFICATIONS_SECTION],
+        NAMEOF(config->group_notifications), config->group_notifications);
 
     // advanced
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION], NAMEOF(config->enableipv6), config->enableipv6);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION], NAMEOF(config->disableudp), config->disableudp);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION], NAMEOF(config->proxyenable), config->proxyenable);
-    write_config_value_int(config_path, config_sections[ADVANCED_SECTION], NAMEOF(config->proxy_port), config->proxy_port);
-    write_config_value_str(config_path, config_sections[ADVANCED_SECTION], NAMEOF(config->proxy_ip), (const char *)config->proxy_ip);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION], NAMEOF(config->force_proxy), config->force_proxy);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION], NAMEOF(config->block_friend_requests), config->block_friend_requests);
+    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
+        NAMEOF(config->enableipv6), config->enableipv6);
+    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
+        NAMEOF(config->disableudp), config->disableudp);
+    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
+        NAMEOF(config->proxyenable), config->proxyenable);
+    write_config_value_int(config_path, config_sections[ADVANCED_SECTION],
+        NAMEOF(config->proxy_port), config->proxy_port);
+    write_config_value_str(config_path, config_sections[ADVANCED_SECTION],
+        NAMEOF(config->proxy_ip), (const char *)config->proxy_ip);
+    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
+        NAMEOF(config->force_proxy), config->force_proxy);
+    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
+        NAMEOF(config->block_friend_requests), config->block_friend_requests);
 
     free(config_path);
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -58,16 +58,16 @@ static const char *config_sections[UNKNOWN_SECTION + 1] = {
 
 SETTINGS settings = {
     // .last_version                // included here to match the full struct
-    .curr_version = UTOX_VERSION_NUMBER,
+    .utox_last_version = UTOX_VERSION_NUMBER,
     .next_version = UTOX_VERSION_NUMBER,
 
     .show_splash = false,
 
     // Low level settings (network, profile, portable-mode)
-    .enable_udp     = true,
-    .enable_ipv6    = true,
+    .disableudp     = false,
+    .enableipv6    = true,
 
-    .use_proxy      = false,
+    .proxyenable      = false,
     .force_proxy    = false,
     .proxy_port     = 0,
 
@@ -79,11 +79,11 @@ SETTINGS settings = {
 
     // User interface settings
     .language               = LANG_EN,
-    .audiofilter_enabled    = true,
+    .audio_filtering_enabled    = true,
     .push_to_talk           = false,
     .audio_preview          = false,
     .video_preview          = false,
-    .send_typing_status     = false,
+    .no_typing_notifications     = true,
     // .inline_video                // included here to match the full struct
     .use_long_time_msg      = true,
     .accept_inline_images   = true,
@@ -92,14 +92,14 @@ SETTINGS settings = {
     .logging_enabled        = true,
     .close_to_tray          = false,
     .start_in_tray          = false,
-    .start_with_system      = false,
+    .auto_startup      = false,
     .use_mini_flist         = false,
     .magic_flist_enabled    = false,
 
     .video_fps              = DEFAULT_FPS,
 
     // Notifications / Alerts
-    .ringtone_enabled       = true,
+    .audible_notifications_enabled       = true,
     .status_notifications   = true,
     .group_notifications    = GNOTIFY_ALWAYS,
 
@@ -445,9 +445,9 @@ UTOX_SAVE *config_load(void) {
     flist_set_filter(save->filter); /* roster list filtering */
 
     /* Network settings */
-    settings.enable_ipv6 = save->enableipv6;
-    settings.enable_udp  = !save->disableudp;
-    settings.use_proxy   = !!save->proxyenable;
+    settings.enableipv6 = save->enableipv6;
+    settings.disableudp  = save->disableudp;
+    settings.proxyenable   = save->proxyenable != 0;
     settings.proxy_port  = save->proxy_port;
     settings.force_proxy = save->force_proxy;
 
@@ -470,16 +470,16 @@ UTOX_SAVE *config_load(void) {
     settings.logging_enabled      = save->logging_enabled;
     settings.close_to_tray        = save->close_to_tray;
     settings.start_in_tray        = save->start_in_tray;
-    settings.start_with_system    = save->auto_startup;
+    settings.auto_startup         = save->auto_startup;
     settings.use_mini_flist       = save->use_mini_flist;
     settings.magic_flist_enabled  = save->magic_flist_enabled;
     settings.use_long_time_msg    = save->use_long_time_msg;
 
-    settings.ringtone_enabled     = save->audible_notifications_enabled;
-    settings.audiofilter_enabled  = save->audio_filtering_enabled;
+    settings.audible_notifications_enabled = save->audible_notifications_enabled;
+    settings.audio_filtering_enabled       = save->audio_filtering_enabled;
 
-    settings.send_typing_status   = !save->no_typing_notifications;
-    settings.status_notifications = save->status_notifications;
+    settings.no_typing_notifications = save->no_typing_notifications;
+    settings.status_notifications    = save->status_notifications;
 
     settings.window_x             = save->window_x;
     settings.window_y             = save->window_y;
@@ -531,23 +531,23 @@ void config_save(UTOX_SAVE *save_in) {
     save->save_version                  = UTOX_SAVE_VERSION;
     save->scale                         = ui_scale;
     save->proxyenable                   = switch_proxy.switch_on;
-    save->audible_notifications_enabled = settings.ringtone_enabled;
-    save->audio_filtering_enabled       = settings.audiofilter_enabled;
+    save->audible_notifications_enabled = settings.audible_notifications_enabled;
+    save->audio_filtering_enabled       = settings.audio_filtering_enabled;
     save->push_to_talk                  = settings.push_to_talk;
 
     /* UX Settings */
     save->logging_enabled               = settings.logging_enabled;
     save->close_to_tray                 = settings.close_to_tray;
     save->start_in_tray                 = settings.start_in_tray;
-    save->auto_startup                  = settings.start_with_system;
+    save->auto_startup                  = settings.auto_startup;
     save->use_mini_flist                = settings.use_mini_flist;
     save->magic_flist_enabled           = settings.magic_flist_enabled;
     save->use_long_time_msg             = settings.use_long_time_msg;
     save->video_fps                     = settings.video_fps;
 
-    save->disableudp                    = !settings.enable_udp;
-    save->enableipv6                    = settings.enable_ipv6;
-    save->no_typing_notifications       = !settings.send_typing_status;
+    save->disableudp                    = settings.disableudp;
+    save->enableipv6                    = settings.enableipv6;
+    save->no_typing_notifications       = settings.no_typing_notifications;
 
     save->filter                        = flist_get_filter();
     save->proxy_port                    = settings.proxy_port;
@@ -557,7 +557,7 @@ void config_save(UTOX_SAVE *save_in) {
     save->audio_device_out              = dropdown_audio_out.selected;
     save->theme                         = settings.theme;
 
-    save->utox_last_version             = settings.curr_version;
+    save->utox_last_version             = settings.utox_last_version;
     save->group_notifications           = settings.group_notifications;
     save->status_notifications          = settings.status_notifications;
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -119,6 +119,9 @@ static void write_config_value_int(const char *filename, const char *section,
         LOG_ERR("Settings", "Unable to save config value: %lu.", value);
     }
 }
+#define WRITE_CONFIG_VALUE_INT(SECTION, VALUE) \
+    write_config_value_int(config_path, config_sections[SECTION], \
+        NAMEOF(VALUE), VALUE)
 
 static void write_config_value_str(const char *filename, const char *section,
                                    const char *key, const char *value) {
@@ -126,6 +129,9 @@ static void write_config_value_str(const char *filename, const char *section,
         LOG_ERR("Settings", "Unable to save config value: %s.", value);
     }
 }
+#define WRITE_CONFIG_VALUE_STR(SECTION, VALUE) \
+    write_config_value_str(config_path, config_sections[SECTION], \
+        NAMEOF(VALUE), (const char *)VALUE)
 
 static void write_config_value_bool(const char *filename, const char *section,
                                     const char *key, const bool value) {
@@ -133,6 +139,9 @@ static void write_config_value_bool(const char *filename, const char *section,
         LOG_ERR("Settings", "Unable to save config value: %s.", value);
     }
 }
+#define WRITE_CONFIG_VALUE_BOOL(SECTION, VALUE) \
+    write_config_value_bool(config_path, config_sections[SECTION], \
+        NAMEOF(VALUE), VALUE)
 
 static CONFIG_SECTION get_section(const char *section) {
     if (MATCH(config_sections[GENERAL_SECTION], section)) {
@@ -342,84 +351,48 @@ static bool utox_save_config(void) {
     SETTINGS *config = &settings;
 
     // general
-    write_config_value_int(config_path, config_sections[GENERAL_SECTION],
-        NAMEOF(config->save_version), config->save_version);
-    write_config_value_int(config_path, config_sections[GENERAL_SECTION],
-        NAMEOF(config->utox_last_version), config->utox_last_version);
+    WRITE_CONFIG_VALUE_INT(GENERAL_SECTION, config->save_version);
+    WRITE_CONFIG_VALUE_INT(GENERAL_SECTION, config->utox_last_version);
 
     // interface
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->language), config->language);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->window_x), config->window_x);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->window_y), config->window_y);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->window_width), config->window_width);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->window_height), config->window_height);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->theme), config->theme);
-    write_config_value_int(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->scale), config->scale);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->logging_enabled), config->logging_enabled);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->close_to_tray), config->close_to_tray);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->start_in_tray), config->start_in_tray);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->auto_startup), config->auto_startup);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->use_mini_flist), config->use_mini_flist);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->filter), config->filter);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->magic_flist_enabled), config->magic_flist_enabled);
-    write_config_value_bool(config_path, config_sections[INTERFACE_SECTION],
-        NAMEOF(config->use_long_time_msg), config->use_long_time_msg);
+    WRITE_CONFIG_VALUE_INT(INTERFACE_SECTION, config->language);
+    WRITE_CONFIG_VALUE_INT(INTERFACE_SECTION, config->window_x);
+    WRITE_CONFIG_VALUE_INT(INTERFACE_SECTION, config->window_y);
+    WRITE_CONFIG_VALUE_INT(INTERFACE_SECTION, config->window_width);
+    WRITE_CONFIG_VALUE_INT(INTERFACE_SECTION, config->window_height);
+    WRITE_CONFIG_VALUE_INT(INTERFACE_SECTION, config->theme);
+    WRITE_CONFIG_VALUE_INT(INTERFACE_SECTION, config->scale);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->logging_enabled);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->close_to_tray);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->start_in_tray);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->auto_startup);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->use_mini_flist);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->filter);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->magic_flist_enabled);
+    WRITE_CONFIG_VALUE_BOOL(INTERFACE_SECTION, config->use_long_time_msg);
 
     // av
-    write_config_value_bool(config_path, config_sections[AV_SECTION],
-        NAMEOF(config->push_to_talk), config->push_to_talk);
-    write_config_value_bool(config_path, config_sections[AV_SECTION],
-        NAMEOF(config->audio_filtering_enabled),
-        config->audio_filtering_enabled);
-    write_config_value_int(config_path, config_sections[AV_SECTION],
-        NAMEOF(config->audio_device_in), config->audio_device_in);
-    write_config_value_int(config_path, config_sections[AV_SECTION],
-        NAMEOF(config->audio_device_out), config->audio_device_out);
-    write_config_value_int(config_path, config_sections[AV_SECTION],
-        NAMEOF(config->video_fps), config->video_fps);
+    WRITE_CONFIG_VALUE_BOOL(AV_SECTION, config->push_to_talk);
+    WRITE_CONFIG_VALUE_BOOL(AV_SECTION, config->audio_filtering_enabled);
+    WRITE_CONFIG_VALUE_INT(AV_SECTION, config->audio_device_in);
+    WRITE_CONFIG_VALUE_INT(AV_SECTION, config->audio_device_out);
+    WRITE_CONFIG_VALUE_INT(AV_SECTION, config->video_fps);
     // TODO: video_input_device
 
     // notifications
-    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION],
-        NAMEOF(config->audible_notifications_enabled),
-        config->audible_notifications_enabled);
-    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION],
-        NAMEOF(config->status_notifications), config->status_notifications);
-    write_config_value_bool(config_path, config_sections[NOTIFICATIONS_SECTION],
-        NAMEOF(config->no_typing_notifications),
-        config->no_typing_notifications);
-    write_config_value_int(config_path, config_sections[NOTIFICATIONS_SECTION],
-        NAMEOF(config->group_notifications), config->group_notifications);
+    WRITE_CONFIG_VALUE_BOOL(NOTIFICATIONS_SECTION, config->audible_notifications_enabled);
+    WRITE_CONFIG_VALUE_BOOL(NOTIFICATIONS_SECTION, config->status_notifications);
+    WRITE_CONFIG_VALUE_BOOL(NOTIFICATIONS_SECTION, config->no_typing_notifications);
+    WRITE_CONFIG_VALUE_INT(NOTIFICATIONS_SECTION, config->group_notifications);
 
     // advanced
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
-        NAMEOF(config->enableipv6), config->enableipv6);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
-        NAMEOF(config->disableudp), config->disableudp);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
-        NAMEOF(config->proxyenable), config->proxyenable);
-    write_config_value_int(config_path, config_sections[ADVANCED_SECTION],
-        NAMEOF(config->proxy_port), config->proxy_port);
-    write_config_value_str(config_path, config_sections[ADVANCED_SECTION],
-        NAMEOF(config->proxy_ip), (const char *)config->proxy_ip);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
-        NAMEOF(config->force_proxy), config->force_proxy);
-    write_config_value_bool(config_path, config_sections[ADVANCED_SECTION],
-        NAMEOF(config->block_friend_requests), config->block_friend_requests);
+    WRITE_CONFIG_VALUE_BOOL(ADVANCED_SECTION, config->enableipv6);
+    WRITE_CONFIG_VALUE_BOOL(ADVANCED_SECTION, config->disableudp);
+    WRITE_CONFIG_VALUE_BOOL(ADVANCED_SECTION, config->proxyenable);
+    WRITE_CONFIG_VALUE_INT(ADVANCED_SECTION, config->proxy_port);
+    WRITE_CONFIG_VALUE_STR(ADVANCED_SECTION, config->proxy_ip);
+    WRITE_CONFIG_VALUE_BOOL(ADVANCED_SECTION, config->force_proxy);
+    WRITE_CONFIG_VALUE_BOOL(ADVANCED_SECTION, config->block_friend_requests);
 
     free(config_path);
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -391,12 +391,6 @@ static UTOX_SAVE *init_default_settings(void) {
 UTOX_SAVE *config_load(void) {
     UTOX_SAVE *save = utox_load_config();
 
-    // TODO: Remove this in ~0.18.0 release
-    if (!save) {
-        LOG_NOTE("Settings", "Unable to load uTox settings from %s. Trying old %s.", config_file_name, config_file_name_old);
-        save = utox_data_load_utox();
-    }
-
     if (!save) {
         LOG_ERR("Settings", "Unable to load uTox settings. Use defaults.");
         save = init_default_settings();
@@ -578,32 +572,4 @@ void config_save(UTOX_SAVE *save_in) {
     }
 
     free(save);
-}
-
-// TODO: Remove this in ~0.18.0 release
-UTOX_SAVE *utox_data_load_utox(void) {
-    size_t size = 0;
-    FILE *fp = utox_get_file(config_file_name_old, &size, UTOX_FILE_OPTS_READ);
-
-    if (!fp) {
-        LOG_ERR("Settings", "Unable to open %s.", config_file_name_old);
-        return NULL;
-    }
-
-    UTOX_SAVE *save = calloc(1, size + 1);
-    if (!save) {
-        LOG_ERR("Settings", "Unable to malloc for %s.", config_file_name_old);
-        fclose(fp);
-        return NULL;
-    }
-
-    if (fread(save, size, 1, fp) != 1) {
-        LOG_ERR("Settings", "Could not read save file %s", config_file_name_old);
-        fclose(fp);
-        free(save);
-        return NULL;
-    }
-
-    fclose(fp);
-    return save;
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -307,11 +307,35 @@ static bool utox_load_config(void) {
     return true;
 }
 
+static bool create_config_folder(char *config_path) {
+    char *last_slash = strrchr(config_path, '/');
+    if (!last_slash) {
+        last_slash = strrchr(config_path, '\\');
+    }
+
+    char *save_folder = strdup(config_path);
+    save_folder[last_slash - config_path + 1] = '\0';
+
+    if (!native_create_dir((uint8_t *)save_folder)) {
+        LOG_ERR("Settings", "Failed to create save folder %s.", save_folder);
+        free(save_folder);
+        return false;
+    }
+
+    free(save_folder);
+    return true;
+}
+
 static bool utox_save_config(void) {
     char *config_path = utox_get_filepath(config_file_name);
 
     if (!config_path) {
         LOG_ERR("Settings", "Unable to get %s path.", config_file_name);
+        return false;
+    }
+
+    if (!create_config_folder(config_path)) {
+        free(config_path);
         return false;
     }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -18,24 +18,23 @@ typedef struct utox_settings {
     uint32_t last_version;
     uint32_t utox_last_version;
 
-    bool     show_splash;
+    bool show_splash;
 
     // Low level settings (network, profile, portable-mode)
-    bool portable_mode;
-
-    bool save_encryption;
-
-    bool force_proxy;
-    bool disableudp;
-    bool enableipv6;
-
-    bool block_friend_requests;
-
-    bool proxyenable;
+    bool     portable_mode;
+    bool     disableudp;
+    bool     enableipv6;
+    bool     proxyenable;
+    bool     force_proxy;
     uint16_t proxy_port;
+
+    // Tox level settings
+    bool block_friend_requests;
+    bool save_encryption;
 
     // User interface settings
     UTOX_LANG language;
+
     bool audio_filtering_enabled;
     bool push_to_talk;
     bool audio_preview;
@@ -64,7 +63,7 @@ typedef struct utox_settings {
     uint8_t  video_fps;
 
     LOG_LVL verbose;
-    FILE *debug_file;
+    FILE *  debug_file;
 
     uint32_t theme;
     uint8_t  scale;

--- a/src/settings.h
+++ b/src/settings.h
@@ -143,20 +143,4 @@ UTOX_SAVE *config_load(void);
  */
 void config_save(UTOX_SAVE *save_in);
 
-
-/**
- * Saves the settings for uTox
- *
- * Returns a bool indicating if it succeeded or not
- */
-bool utox_data_save_utox(UTOX_SAVE *data, size_t length);
-
-/**
- * Loads uTox settings
- *
- * Returns a memory pointer of *size, the caller needs to free this
- * Returns NULL on failure
- */
-UTOX_SAVE *utox_data_load_utox(void);
-
 #endif

--- a/src/settings.h
+++ b/src/settings.h
@@ -17,7 +17,7 @@ extern uint16_t loaded_audio_in_device, loaded_audio_out_device;
 typedef struct utox_settings {
     // uTox versions settings
     uint32_t last_version;
-    uint32_t curr_version;
+    uint32_t utox_last_version;
     uint32_t next_version;
 
     bool     show_splash;
@@ -32,21 +32,21 @@ typedef struct utox_settings {
     bool send_version;      /* Unused, included for compatibility */
 
     bool force_proxy;
-    bool enable_udp;
-    bool enable_ipv6;
+    bool disableudp;
+    bool enableipv6;
 
     bool block_friend_requests;
 
-    bool use_proxy;
+    bool proxyenable;
     uint16_t proxy_port;
 
     // User interface settings
     UTOX_LANG language;
-    bool audiofilter_enabled;
+    bool audio_filtering_enabled;
     bool push_to_talk;
     bool audio_preview;
     bool video_preview;
-    bool send_typing_status;
+    bool no_typing_notifications;
     bool inline_video;
     bool use_long_time_msg;
     bool accept_inline_images;
@@ -55,12 +55,12 @@ typedef struct utox_settings {
     bool logging_enabled;
     bool close_to_tray;
     bool start_in_tray;
-    bool start_with_system;
+    bool auto_startup;
     bool use_mini_flist;
     bool magic_flist_enabled;
 
     // Notifications / Alerts
-    bool    ringtone_enabled;
+    bool    audible_notifications_enabled;
     bool    status_notifications;
     uint8_t group_notifications;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,8 +1,6 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-typedef struct utox_save UTOX_SAVE;
-
 #include "debug.h"
 #include "../langs/i18n_decls.h"
 
@@ -10,15 +8,15 @@ typedef struct utox_save UTOX_SAVE;
 #include <stdint.h>
 #include <stdbool.h>
 
+/* House keeping for uTox save file. */
+#define UTOX_SAVE_VERSION 4
 #define DEFAULT_FPS 25
 
-extern uint16_t loaded_audio_in_device, loaded_audio_out_device;
-
 typedef struct utox_settings {
-    // uTox versions settings
+    uint8_t  save_version;
+
     uint32_t last_version;
     uint32_t utox_last_version;
-    uint32_t next_version;
 
     bool     show_splash;
 
@@ -26,10 +24,6 @@ typedef struct utox_settings {
     bool portable_mode;
 
     bool save_encryption;
-
-    bool auto_update;       /* Unused, included for compatibility */
-    bool update_to_develop; /* Unused, included for compatibility */
-    bool send_version;      /* Unused, included for compatibility */
 
     bool force_proxy;
     bool disableudp;
@@ -57,6 +51,7 @@ typedef struct utox_settings {
     bool start_in_tray;
     bool auto_startup;
     bool use_mini_flist;
+    bool filter;
     bool magic_flist_enabled;
 
     // Notifications / Alerts
@@ -64,10 +59,15 @@ typedef struct utox_settings {
     bool    status_notifications;
     uint8_t group_notifications;
 
+    uint16_t audio_device_out;
+    uint16_t audio_device_in;
+    uint8_t  video_fps;
+
     LOG_LVL verbose;
     FILE *debug_file;
 
     uint32_t theme;
+    uint8_t  scale;
 
     // OS interface settings
     uint32_t window_x;
@@ -75,72 +75,21 @@ typedef struct utox_settings {
     uint32_t window_height;
     uint32_t window_width;
     uint32_t window_baseline;
+    bool     window_maximized;
 
-    bool    window_maximized;
-    uint8_t video_fps;
+    uint8_t proxy_ip[];
 } SETTINGS;
 
 extern SETTINGS settings;
 
-/* House keeping for uTox save file. */
-#define UTOX_SAVE_VERSION 3
-typedef struct utox_save {
-    uint8_t save_version;
-    uint8_t scale;
-    uint8_t enableipv6;
-    uint8_t disableudp;
-
-    uint16_t window_x, window_y, window_width, window_height;
-    uint16_t proxy_port;
-
-    uint8_t proxyenable;
-
-    uint8_t logging_enabled : 1;
-    uint8_t audible_notifications_enabled : 1;
-    uint8_t filter : 1;
-    uint8_t audio_filtering_enabled : 1;
-    uint8_t close_to_tray : 1;
-    uint8_t start_in_tray : 1;
-    uint8_t auto_startup : 1;
-    uint8_t no_typing_notifications : 1;
-
-    uint16_t audio_device_in;
-    uint16_t audio_device_out;
-
-    uint8_t theme;
-
-    uint8_t push_to_talk         : 1;
-    uint8_t use_mini_flist       : 1;
-    uint8_t group_notifications  : 4;
-    uint8_t status_notifications : 1;
-    uint8_t magic_flist_enabled  : 1;
-
-    uint32_t utox_last_version; // I don't like this here either,
-    // but I'm not ready to rewrite and update this struct yet.
-
-    uint8_t auto_update         : 1; /* Unused, included for compatibility */
-    uint8_t update_to_develop   : 1; /* Unused, included for compatibility */
-    uint8_t send_version        : 1; /* Unused, included for compatibility */
-    uint8_t zero_2              : 5;
-    uint8_t zero_3              : 8;
-
-    uint16_t language;
-    uint8_t video_fps;
-    uint8_t force_proxy;
-    uint8_t use_long_time_msg;
-
-    uint8_t  unused[51];
-    uint8_t  proxy_ip[];
-} UTOX_SAVE;
+/*
+ * Loads settings from disk
+ */
+void config_load(void);
 
 /*
- * Loads the config file and returns a settings struct
+ * Writes settings to disk
  */
-UTOX_SAVE *config_load(void);
-
-/*
- * Writes save_in to the disk
- */
-void config_save(UTOX_SAVE *save_in);
+void config_save(void);
 
 #endif

--- a/src/tox.c
+++ b/src/tox.c
@@ -347,8 +347,8 @@ static int init_toxcore(Tox **tox) {
 
     tox_options_set_log_callback(&topt, log_callback);
 
-    tox_options_set_ipv6_enabled(&topt, settings.enable_ipv6);
-    tox_options_set_udp_enabled(&topt, settings.enable_udp);
+    tox_options_set_ipv6_enabled(&topt, settings.enableipv6);
+    tox_options_set_udp_enabled(&topt, !settings.disableudp);
 
     tox_options_set_proxy_type(&topt, TOX_PROXY_TYPE_NONE);
     tox_options_set_proxy_host(&topt, proxy_address);
@@ -384,7 +384,7 @@ static int init_toxcore(Tox **tox) {
     }
     postmessage_utox(REDRAW, 0, 0, NULL);
 
-    if (settings.use_proxy) {
+    if (settings.proxyenable) {
         topt.proxy_type = TOX_PROXY_TYPE_SOCKS5;
     }
 
@@ -409,7 +409,7 @@ static int init_toxcore(Tox **tox) {
 
         // reset proxy options as well as GUI and settings
         topt.proxy_type = TOX_PROXY_TYPE_NONE;
-        settings.use_proxy = settings.force_proxy = 0;
+        settings.proxyenable = settings.force_proxy = 0;
         switch_proxy.switch_on = 0;
 
         *tox = tox_new(&topt, &tox_new_err);
@@ -419,7 +419,7 @@ static int init_toxcore(Tox **tox) {
 
             // reset IPv6 options as well as GUI and settings
             topt.ipv6_enabled = 0;
-            switch_ipv6.switch_on = settings.enable_ipv6 = 0;
+            switch_ipv6.switch_on = settings.enableipv6 = 0;
 
             *tox = tox_new(&topt, &tox_new_err);
 
@@ -436,7 +436,7 @@ static int init_toxcore(Tox **tox) {
     set_callbacks(*tox);
 
     /* Connect to bootstrapped nodes in "tox_bootstrap.h" */
-    toxcore_bootstrap(*tox, settings.enable_ipv6);
+    toxcore_bootstrap(*tox, settings.enableipv6);
 
     if (save_status == -2) {
         LOG_NOTE("Toxcore", "No save file, using defaults" );
@@ -534,7 +534,7 @@ void toxcore_thread(void *UNUSED(args)) {
             if (time - last_connection >= (uint64_t)10 * 1000 * 1000 * 1000) {
                 last_connection = time;
                 if (!connected) {
-                    toxcore_bootstrap(tox, settings.enable_ipv6);
+                    toxcore_bootstrap(tox, settings.enableipv6);
                 }
 
                 // save every 1000.
@@ -560,7 +560,7 @@ void toxcore_thread(void *UNUSED(args)) {
                 typing_state.sent = (msg->msg == TOX_SEND_MESSAGE || msg->msg == TOX_SEND_ACTION);
             }
 
-            if (settings.send_typing_status) {
+            if (!settings.no_typing_notifications) {
                 // Thread active transfers and check if friend is typing
                 utox_thread_work_for_typing_notifications(tox, time);
             }

--- a/src/utox.c
+++ b/src/utox.c
@@ -123,24 +123,24 @@ void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param
                 dropdown_list_add_localized(&dropdown_audio_in, param1, data);
             }
 
-            if (loaded_audio_in_device == (uint16_t)~0 && param2) {
-                loaded_audio_in_device = (dropdown_audio_in.dropcount - 1);
+            if (settings.audio_device_in == (uint16_t)~0 && param2) {
+                settings.audio_device_in = (dropdown_audio_in.dropcount - 1);
             }
 
-            if (loaded_audio_in_device != 0 && (dropdown_audio_in.dropcount - 1) == loaded_audio_in_device) {
+            if (settings.audio_device_in != 0 && (dropdown_audio_in.dropcount - 1) == settings.audio_device_in) {
                 postmessage_utoxav(UTOXAV_SET_AUDIO_IN, 0, 0, data);
-                dropdown_audio_in.selected = loaded_audio_in_device;
-                loaded_audio_in_device     = 0;
+                dropdown_audio_in.selected = settings.audio_device_in;
+                settings.audio_device_in   = 0;
             }
             break;
         }
         case AUDIO_OUT_DEVICE: {
             dropdown_list_add_hardcoded(&dropdown_audio_out, data, data);
 
-            if (loaded_audio_out_device != 0 && (dropdown_audio_out.dropcount - 1) == loaded_audio_out_device) {
+            if (settings.audio_device_out != 0 && (dropdown_audio_out.dropcount - 1) == settings.audio_device_out) {
                 postmessage_utoxav(UTOXAV_SET_AUDIO_OUT, 0, 0, data);
-                dropdown_audio_out.selected = loaded_audio_out_device;
-                loaded_audio_out_device     = 0;
+                dropdown_audio_out.selected = settings.audio_device_out;
+                settings.audio_device_out   = 0;
             }
 
             break;

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -810,13 +810,6 @@ void setscale(void) {
     svg_draw(1);
 }
 
-void config_osdefaults(UTOX_SAVE *r) {
-    r->window_x      = (GetSystemMetrics(SM_CXSCREEN) - MAIN_WIDTH) / 2;
-    r->window_y      = (GetSystemMetrics(SM_CYSCREEN) - MAIN_HEIGHT) / 2;
-    r->window_width  = MAIN_WIDTH;
-    r->window_height = MAIN_HEIGHT;
-}
-
 /*
  * CommandLineToArgvA implementation since CommandLineToArgvA doesn't exist in win32 api
  * Limitation: nested quotation marks are not handled

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -1064,6 +1064,16 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
         DispatchMessage(&msg);
     }
 
+    RECT wndrect = { 0 };
+    GetWindowRect(main_window.window, &wndrect);
+
+    settings.window_x      = wndrect.left < 0 ? 0 : wndrect.left;
+    settings.window_y      = wndrect.top < 0 ? 0 : wndrect.top;
+    settings.window_width  = (wndrect.right - wndrect.left);
+    settings.window_height = (wndrect.bottom - wndrect.top);
+
+    config_save();
+
     /* kill threads */
     postmessage_utoxav(UTOXAV_KILL, 0, 0, NULL);
     postmessage_toxcore(TOX_KILL, 0, 0, NULL);
@@ -1076,16 +1086,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
     while (tox_thread_init) {
         yieldcpu(10);
     }
-
-    RECT wndrect = { 0 };
-    GetWindowRect(main_window.window, &wndrect);
-
-    settings.window_x      = wndrect.left < 0 ? 0 : wndrect.left;
-    settings.window_y      = wndrect.top < 0 ? 0 : wndrect.top;
-    settings.window_width  = (wndrect.right - wndrect.left);
-    settings.window_height = (wndrect.bottom - wndrect.top);
-
-    config_save();
 
     // TODO: This should be a non-zero value determined by a message's wParam.
     return 0;

--- a/src/windows/main.c
+++ b/src/windows/main.c
@@ -1079,13 +1079,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE UNUSED(hPrevInstance), PSTR cm
 
     RECT wndrect = { 0 };
     GetWindowRect(main_window.window, &wndrect);
-    UTOX_SAVE d = {
-        .window_x      = wndrect.left < 0 ? 0 : wndrect.left,
-        .window_y      = wndrect.top < 0 ? 0 : wndrect.top,
-        .window_width  = (wndrect.right - wndrect.left),
-        .window_height = (wndrect.bottom - wndrect.top),
-    };
-    config_save(&d);
+
+    settings.window_x      = wndrect.left < 0 ? 0 : wndrect.left;
+    settings.window_y      = wndrect.top < 0 ? 0 : wndrect.top;
+    settings.window_width  = (wndrect.right - wndrect.left);
+    settings.window_height = (wndrect.bottom - wndrect.top);
+
+    config_save();
 
     // TODO: This should be a non-zero value determined by a message's wParam.
     return 0;

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -12,7 +12,7 @@
 #include "../flist.h"
 #include "../friend.h"
 #include "../macros.h"
-#include "../main.h" // MAIN_WIDTH, MAIN_WIDTH, DEFAULT_SCALE, parse_args, utox_init
+#include "../main.h" // MAIN_WIDTH, MAIN_WIDTH, parse_args, utox_init
 #include "../settings.h"
 #include "../text.h"
 #include "../theme.h"
@@ -652,13 +652,6 @@ void showkeyboard(bool UNUSED(show)) {}
 void edit_will_deactivate(void) {}
 
 void update_tray(void) {}
-
-void config_osdefaults(UTOX_SAVE *r) {
-    r->window_x      = 0;
-    r->window_y      = 0;
-    r->window_width  = DEFAULT_WIDTH;
-    r->window_height = DEFAULT_HEIGHT;
-}
 
 static void atom_init(void) {
     wm_protocols     = XInternAtom(display, "WM_PROTOCOLS", 0);

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -867,15 +867,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    postmessage_utoxav(UTOXAV_KILL, 0, 0, NULL);
-    postmessage_toxcore(TOX_KILL, 0, 0, NULL);
-
-    /* free client thread stuff */
-    if (libgtk) {
-    }
-
-    destroy_tray_icon();
-
     Window       root_return, child_return;
     int          x_return, y_return;
     unsigned int width_return, height_return, i;
@@ -889,6 +880,15 @@ int main(int argc, char *argv[]) {
     settings.window_height = height_return;
 
     config_save();
+
+    postmessage_utoxav(UTOXAV_KILL, 0, 0, NULL);
+    postmessage_toxcore(TOX_KILL, 0, 0, NULL);
+
+    /* free client thread stuff */
+    if (libgtk) {
+    }
+
+    destroy_tray_icon();
 
     FcFontSetSortDestroy(fs);
     freefonts();

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -883,14 +883,12 @@ int main(int argc, char *argv[]) {
 
     XTranslateCoordinates(display, main_window.window, root_return, 0, 0, &x_return, &y_return, &child_return);
 
-    UTOX_SAVE d = {
-        .window_x      = x_return < 0 ? 0 : x_return,
-        .window_y      = y_return < 0 ? 0 : y_return,
-        .window_width  = width_return,
-        .window_height = height_return,
-    };
+    settings.window_x      = x_return < 0 ? 0 : x_return;
+    settings.window_y      = y_return < 0 ? 0 : y_return;
+    settings.window_width  = width_return;
+    settings.window_height = height_return;
 
-    config_save(&d);
+    config_save();
 
     FcFontSetSortDestroy(fs);
     freefonts();

--- a/src/xlib/main.h
+++ b/src/xlib/main.h
@@ -22,9 +22,6 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
-#define DEFAULT_WIDTH (382 * DEFAULT_SCALE)
-#define DEFAULT_HEIGHT (320 * DEFAULT_SCALE)
-
 typedef struct native_image NATIVE_IMAGE;
 struct native_image {
     // This is really a Picture, but it is just a typedef for XID, and I didn't

--- a/tests/mock/mock_settings.c
+++ b/tests/mock/mock_settings.c
@@ -5,15 +5,15 @@
 
 
 SETTINGS settings = {
-    .curr_version = UTOX_VERSION_NUMBER,
+    .utox_last_version = UTOX_VERSION_NUMBER,
     // .last_version                // included here to match the full struct
     .show_splash = false,
 
     // Low level settings (network, profile, portable-mode)
-    .enable_udp     = true,
-    .enable_ipv6    = true,
+    .disableudp     = false,
+    .enableipv6     = true,
 
-    .use_proxy      = false,
+    .proxyenable    = false,
     .force_proxy    = false,
     .proxy_port     = 0,
 
@@ -26,22 +26,22 @@ SETTINGS settings = {
 
 
     // User interface settings
-    .close_to_tray          = false,
-    .logging_enabled        = true,
-    .audiofilter_enabled    = true,
-    .start_in_tray          = false,
-    .start_with_system      = false,
-    .push_to_talk           = false,
-    .audio_preview          = false,
-    .video_preview          = false,
-    .send_typing_status     = false,
-    .use_mini_flist         = false,
+    .close_to_tray           = false,
+    .logging_enabled         = true,
+    .audio_filtering_enabled = true,
+    .start_in_tray           = false,
+    .auto_startup            = false,
+    .push_to_talk            = false,
+    .audio_preview           = false,
+    .video_preview           = false,
+    .no_typing_notifications = true,
+    .use_mini_flist          = false,
     // .inline_video                // included here to match the full struct
-    .use_long_time_msg      = true,
-    .accept_inline_images   = true,
+    .use_long_time_msg       = true,
+    .accept_inline_images    = true,
 
     // Notifications / Alerts
-    .ringtone_enabled       = true,
+    .audible_notifications_enabled = true,
     .status_notifications   = true,
     .group_notifications    = 0,
 
@@ -57,35 +57,10 @@ SETTINGS settings = {
     .window_maximized     = 0,
 };
 
-/*
- * Loads the config file and returns a settings struct
- */
-UTOX_SAVE *config_load(void) {
+void config_load(void) {
     FAIL_FATAL("called a mocked function, this should not happen: %s", __FUNCTION__);
 }
 
-/*
- * Writes save_in to the disk
- */
-void config_save(UTOX_SAVE *save_in) {
-    FAIL_FATAL("called a mocked function, this should not happen: %s", __FUNCTION__);
-}
-
-/**
- * Saves the settings for uTox
- *
- * Returns a bool indicating if it succeeded or not
- */
-bool utox_data_save_utox(UTOX_SAVE *data, size_t length) {
-    FAIL_FATAL("called a mocked function, this should not happen: %s", __FUNCTION__);
-}
-
-/**
- * Loads uTox settings
- *
- * Returns a memory pointer of *size, the caller needs to free this
- * Returns NULL on failure
- */
-UTOX_SAVE *utox_data_load_utox(void) {
+void config_save(void) {
     FAIL_FATAL("called a mocked function, this should not happen: %s", __FUNCTION__);
 }


### PR DESCRIPTION
* drop old and deprecated settings binary format
* drop `UTOX_SAVE` struct because its only purpose was hold data from `SETTINGS` struct and dump it to the disk
* drop unused function `config_osdefaults`
* all fields in the `SETTINGS` struct renamed to match fields from `UTOX_SAVE` because they are loaded from the file with `NAMEOF` macro and we don't want return to the tons of the consts strings
* drop unused parameters (`auto_update`, ...) and add missing (`block_friend_requests`)
* save settings after failed load attempt (uTox first run)
* save settings right after begining of the shutdown process (fixes #1457)
* enforce codestyle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1458)
<!-- Reviewable:end -->
