### PR TITLE
Fix crash when mouse is down on an flist item and goes outside of flist

### DIFF
--- a/src/flist.c
+++ b/src/flist.c
@@ -1058,6 +1058,9 @@ bool flist_mmove(void *UNUSED(n), int UNUSED(x), int UNUSED(y), int UNUSED(width
     }
 
     ITEM *i = item_hit(mx, my, height);
+    if (!i) {
+        return false;
+    }
 
     bool draw = false;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1468)
<!-- Reviewable:end -->
