### PR TITLE
src/xlib/CMakeLists.txt: compile dbus.{c,h} conditionally

### DIFF
--- a/src/xlib/CMakeLists.txt
+++ b/src/xlib/CMakeLists.txt
@@ -24,8 +24,7 @@ set_target_properties( icon PROPERTIES LINKER_LANGUAGE C )
 #########################################
 add_library(utoxNATIVE STATIC
     audio.c
-    dbus.c
-    dbus.h
+    $<$<BOOL:${ENABLE_DBUS}>:dbus.c dbus.h>
     drawing.c
     event.c
     filesys.c


### PR DESCRIPTION
This fixes the following warning, when `-DENABLE_DBUS=OFF`:

```
src/xlib/dbus.c:118: warning: ISO C forbids an empty translation unit [-Wpedantic]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1481)
<!-- Reviewable:end -->
