### PR TITLE
src/xlib/CMakeLists.txt: compile mmenu.{c,h} conditionally

### DIFF
--- a/src/xlib/CMakeLists.txt
+++ b/src/xlib/CMakeLists.txt
@@ -34,8 +34,7 @@ add_library(utoxNATIVE STATIC
     keysym2ucs.h
     main.c
     main.h
-    mmenu.c
-    mmenu.h
+    $<$<BOOL:${ENABLE_UNITY_MMENU}>:mmenu.c>
     screen_grab.c
     tray.c
     v4l.c


### PR DESCRIPTION
This fixes the following warning:

```
src/xlib/mmenu.c:153: warning: ISO C forbids an empty translation unit [-Wpedantic]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1483)
<!-- Reviewable:end -->
