### PR TITLE
Fix crash when changing toxcore-related settings

### DIFF
--- a/src/av/audio.c
+++ b/src/av/audio.c
@@ -909,6 +909,7 @@ void utox_audio_thread(void *args) {
     }
 
     utox_filter_audio_kill(f_a);
+    f_a = NULL;
 
     // missing some cleanup ?
     alDeleteSources(1, &ringtone);

--- a/src/av/utox_av.c
+++ b/src/av/utox_av.c
@@ -275,7 +275,6 @@ void utox_av_ctrl_thread(void *UNUSED(args)) {
                 }
             }
         }
-
         toxav_thread_msg = false;
 
         if (av) {
@@ -286,19 +285,17 @@ void utox_av_ctrl_thread(void *UNUSED(args)) {
         }
     }
 
-
     postmessage_audio(UTOXAUDIO_KILL, 0, 0, NULL);
     postmessage_video(UTOXVIDEO_KILL, 0, 0, NULL);
-
     // Wait for all a/v threads to return 0
     while (utox_audio_thread_init || utox_video_thread_init) {
         yieldcpu(1);
     }
 
-    toxav_thread_msg  = false;
+    toxav_kill(av);
+
     utox_av_ctrl_init = false;
 
-    toxav_kill(av);
     LOG_NOTE("UTOXAV", "Clean thread exit!");
     return;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -270,9 +270,6 @@ void utox_init(void) {
         settings.show_splash = true;
         settings.utox_last_version = settings.last_version;
     }
-
-    // We likely want to start this on every system.
-    thread(utox_av_ctrl_thread, NULL);
 }
 
 void utox_raze(void) {


### PR DESCRIPTION
uTox killed toxcore without killing toxav first, which led to a crash. Resources should be deallocated in reverse order of their allocation.

utox_av_ctrl_thread was started only once, when uTox was started, so when toxav was killed properly, the thread was never re-created for the next use of Tox. utox_av_ctrl_thread
is now created whenever a new toxcore starts.

Then, the Filter_Audio pointer had to be set to NULL after it's free'd, otherwise it wouldn't get re-initialised, and an invalid pointer would be passed to kill_filter_audio(), causing a crash.

Finally, replaced magic number 0 with TOX_KILL.
Deleted a redundant `toxav_thread_msg = false`.

Fixes #1478
Fixes #1441
Fixes #1416
Fixes #1376
Fixes #1280
Fixes #1266
Fixes #1252
Closes https://github.com/TokTok/c-toxcore/issues/1149
Closes #1312

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1486)
<!-- Reviewable:end -->
