### PR TITLE
Add Debian installation instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,6 +7,7 @@ For any and all of the following, you'll need to have [toxcore](https://github.c
 - [Windows](#windows)
 - [Unix-like](#unix-like)
   - [Archlinux](#archlinux)
+  - [Debian](#debian)
   - [Slackware](#slackware)
   - [Other distributions](#other-distributions)
 - [OpenBSD](#openBSD)
@@ -53,6 +54,13 @@ Install by running:
 
 ```bash
 sudo pacman -S utox
+```
+
+### Debian
+
+Install by running:
+```bash
+sudo apt install utox
 ```
 
 ### Slackware


### PR DESCRIPTION
Fixes #1500 
I've used `sudo apt install utox` to install on Debian 10 with complete success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1501)
<!-- Reviewable:end -->
