### PR TITLE
Disable -Werror for 3rd party projects

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_cflag("-Wno-error")
+
 add_subdirectory(minini)
 add_subdirectory(qrcodegen)
 add_subdirectory(stb)


### PR DESCRIPTION
third_party/stb compiles with (scary) warnings. We should fix that but it
should not prevent a -Werror build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1512)
<!-- Reviewable:end -->
