### PR TITLE
Use correct type for pthread entry point

### DIFF
--- a/src/tox.c
+++ b/src/tox.c
@@ -452,7 +452,7 @@ static int init_toxcore(Tox **tox) {
  *
  * Accepts and returns nothing.
  */
-void toxcore_thread(void *UNUSED(args)) {
+void *toxcore_thread(void *UNUSED(args)) {
     ToxAV *av               = NULL;
     bool   reconfig         = 1;
     int    toxcore_init_err = 0;
@@ -584,6 +584,7 @@ void toxcore_thread(void *UNUSED(args)) {
     free_friends();
     raze_groups();
     LOG_TRACE("Toxcore", "Tox thread:\tClean exit!");
+    return NULL;
 }
 
 /** General recommendations for working with threads in uTox

--- a/src/tox.h
+++ b/src/tox.h
@@ -129,7 +129,7 @@ void tox_after_load(Tox *tox);
 
 /* toxcore thread
  */
-void toxcore_thread(void *args);
+void *toxcore_thread(void *args);
 
 /* send a message to the toxcore thread
  */

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -212,12 +212,12 @@ void image_set_filter(NATIVE_IMAGE *image, uint8_t filter) {
     }
 }
 
-void thread(void func(void *), void *args) {
+void thread(void *func(void *), void *args) {
     pthread_t      thread_temp;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setstacksize(&attr, 1 << 20);
-    pthread_create(&thread_temp, &attr, (void *(*)(void *))func, args);
+    pthread_create(&thread_temp, &attr, func, args);
     pthread_attr_destroy(&attr);
 }
 

--- a/tests/mock/mock_threads.c
+++ b/tests/mock/mock_threads.c
@@ -1,10 +1,10 @@
 #include <pthread.h>
 
-void thread(void func(void *), void *args) {
+void thread(void * (*func)(void *), void *args) {
     pthread_t      thread_temp;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setstacksize(&attr, 1 << 20);
-    pthread_create(&thread_temp, &attr, (void *(*)(void *))func, args);
+    pthread_create(&thread_temp, &attr, func, args);
     pthread_attr_destroy(&attr);
 }


### PR DESCRIPTION
This way we don't need to cast. Seems reasonable given that we want to treat
all warnings as errors. I got this one:

tests/mock/mock_threads.c:8:41: error: cast between incompatible function types from ‘void (*)(void *)’ to ‘void * (*)(void *)’ [-Werror=cast-function-type]
    8 |     pthread_create(&thread_temp, &attr, (void *(*)(void *))func, args);

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1514)
<!-- Reviewable:end -->
