### PR TITLE
Solved crash when undoing chat input with ctrl-z

### DIFF
--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -354,13 +354,17 @@ static uint16_t edit_change_do(EDIT *edit, EDIT_CHANGE *c) {
 void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
     EDIT_CHANGE *new, **history;
 
+    if (edit->history_cur != edit->history_length) {
+        uint16_t i = edit->history_cur;
+        while (i != edit->history_length) {
+            free(edit->history[i++]);
+        }
+    }
+
     history = realloc(edit->history, (edit->history_cur + 1) * sizeof(void *));
     if (!history) {
         LOG_FATAL_ERR(EXIT_MALLOC, "UI Edit", "Unable to realloc for edit history, this should never happen!");
     }
-    /* Note: if we access edit->history after reallocing it, we're using
-       potentially freed memory.
-    */
     edit->history = history;
 
     new = calloc(1, sizeof(EDIT_CHANGE) + length);
@@ -372,13 +376,6 @@ void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
     new->start  = start;
     new->length = length;
     memcpy(new->data, edit->data + start, length);
-
-    if (edit->history_cur != edit->history_length) {
-        uint16_t i = edit->history_cur;
-        while (i != edit->history_length) {
-            free(edit->history[i++]);
-        }
-    }
 
     history[edit->history_cur] = new;
 

--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -352,7 +352,7 @@ static uint16_t edit_change_do(EDIT *edit, EDIT_CHANGE *c) {
 }
 
 void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
-    EDIT_CHANGE *new, **history;
+    EDIT_CHANGE *new;
 
     if (edit->history_cur != edit->history_length) {
         uint16_t i = edit->history_cur;
@@ -361,11 +361,10 @@ void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
         }
     }
 
-    history = realloc(edit->history, (edit->history_cur + 1) * sizeof(void *));
-    if (!history) {
+    edit->history = realloc(edit->history, (edit->history_cur + 1) * sizeof(void *));
+    if (!edit->history) {
         LOG_FATAL_ERR(EXIT_MALLOC, "UI Edit", "Unable to realloc for edit history, this should never happen!");
     }
-    edit->history = history;
 
     new = calloc(1, sizeof(EDIT_CHANGE) + length);
     if (!new) {
@@ -377,8 +376,7 @@ void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
     new->length = length;
     memcpy(new->data, edit->data + start, length);
 
-    history[edit->history_cur] = new;
-
+    edit->history[edit->history_cur] = new;
     edit->history_cur++;
     edit->history_length = edit->history_cur;
 }

--- a/src/ui/edit.c
+++ b/src/ui/edit.c
@@ -352,7 +352,7 @@ static uint16_t edit_change_do(EDIT *edit, EDIT_CHANGE *c) {
 }
 
 void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
-    EDIT_CHANGE *new;
+    EDIT_CHANGE *new_change;
 
     if (edit->history_cur != edit->history_length) {
         uint16_t i = edit->history_cur;
@@ -366,17 +366,17 @@ void edit_do(EDIT *edit, uint16_t start, uint16_t length, bool remove) {
         LOG_FATAL_ERR(EXIT_MALLOC, "UI Edit", "Unable to realloc for edit history, this should never happen!");
     }
 
-    new = calloc(1, sizeof(EDIT_CHANGE) + length);
-    if (!new) {
+    new_change = calloc(1, sizeof(EDIT_CHANGE) + length);
+    if (!new_change) {
         LOG_FATAL_ERR(EXIT_MALLOC, "UI Edit", "Unable to calloc for new EDIT_CHANGE, this should never happen!");
     }
 
-    new->remove = remove;
-    new->start  = start;
-    new->length = length;
-    memcpy(new->data, edit->data + start, length);
+    new_change->remove = remove;
+    new_change->start  = start;
+    new_change->length = length;
+    memcpy(new_change->data, edit->data + start, length);
 
-    edit->history[edit->history_cur] = new;
+    edit->history[edit->history_cur] = new_change;
     edit->history_cur++;
     edit->history_length = edit->history_cur;
 }


### PR DESCRIPTION
Solved a bug that caused a crash when text from chat was undone using ctrl-z.
It should solve issue #1072.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1523)
<!-- Reviewable:end -->
