### PR TITLE
Fix double free in flist when changing settings w/ empty flist

### DIFF
--- a/src/flist.c
+++ b/src/flist.c
@@ -820,6 +820,11 @@ void flist_delete_rmouse_item(void) {
 }
 
 void flist_freeall(void) {
+    if (!item) {
+        LOG_ERR("F-List", "Friend list is already NULL!");
+        return;
+    }
+
     for (ITEM *i = item; i != item + itemcount; i++) {
         switch (i->type) {
             case ITEM_FRIEND: {
@@ -845,7 +850,9 @@ void flist_freeall(void) {
     itemcount  = 0;
     showncount = 0;
     free(item);
+    item = NULL;
     free(shown_list);
+    shown_list = NULL;
 }
 
 void flist_selectchat(int index) {


### PR DESCRIPTION
This pretty much only happens if you double-click e.g. the udp toggle to
trigger a restart of tox twice in rapid succession. The first restart
calls flist_freeall() which empties the flist and leaves old pointers in
`item` and `shown_list` and the second flist_freeall() will try to free
the old pointers again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1525)
<!-- Reviewable:end -->
