### PR TITLE
IRC: Move to libera.chat away from freenode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# μTox [![IRC: #utox on freenode](https://img.shields.io/badge/freenode-%23utox-brightgreen.svg)](https://webchat.freenode.net/?channels=#utox) ![Actions Build Status](https://github.com/uTox/uTox/workflows/.github/workflows/ci.yaml/badge.svg) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/utox/utox?branch=develop&svg=true)](https://ci.appveyor.com/project/utox/utox)
+# μTox [![IRC: #utox on libera.chat](https://img.shields.io/badge/libera.chat-%23utox-brightgreen.svg)](https://web.libera.chat/?channels=#utox) ![Actions Build Status](https://github.com/uTox/uTox/workflows/.github/workflows/ci.yaml/badge.svg) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/utox/utox?branch=develop&svg=true)](https://ci.appveyor.com/project/utox/utox)
 
 The lightweight [Tox](https://github.com/TokTok/toxcore) client.
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,6 +1,6 @@
 # Build
 
-Following are barebone compilation instructions. They probably won't work but #utox on freenode can
+Following are barebone compilation instructions. They probably won't work but #utox on libera.chat can
 probably help you out.
 
 If you're looking for it to "just work" you're going to want [these instructions](INSTALL.md).
@@ -266,4 +266,4 @@ java -classpath $SDK_PATH/tools/lib/sdklib.jar com.android.sdklib.build.ApkBuild
 jarsigner -sigalg SHA1withRSA -digestalg SHA1 -keystore ./tmp/debug.keystore -storepass $PASSWORD ./tmp/tmp2.apk $ALIAS
 ```
 
-Come to think of it, this section is woefully out of date. The android build script in tools/ is likely to be more helpful at this point. Or come to [#utox on Freenode](https://webchat.freenode.net/?channels=#utox) and ask for grayhatter. If you're interested in working on android. He'll get you a build environment set up!
+Come to think of it, this section is woefully out of date. The android build script in tools/ is likely to be more helpful at this point. Or come to [#utox on libera.chat](https://web.libera.chat/?channels=#utox) and ask for grayhatter. If you're interested in working on android. He'll get you a build environment set up!


### PR DESCRIPTION
Freenode has become distrustworthy and the channel is no more under our
control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/utox/utox/1540)
<!-- Reviewable:end -->
